### PR TITLE
Add fixture-backed downloads queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,11 @@ temp/
 
 # OS generated
 Thumbs.db
+
+# Android/Gradle
+android/.gradle/
+android/local.properties
+android/**/*.iml
+android/.idea/
+android/app/build/
+android/build/

--- a/CHIRUI_ROADMAP.md
+++ b/CHIRUI_ROADMAP.md
@@ -1,286 +1,91 @@
-# Chirui (チルい) Reader Project - Roadmap
+# Chirui (チルい) Reader - Native Kotatsu Roadmap
 
-## Project Overview
-Recreate the Chirui (チルい) Reader manga reader application, starting with a web-based version deployable to GitHub Pages, then evolving to a native Android application.
+Chirui Reader is now focused exclusively on a **native Kotlin/Jetpack Compose application** that recreates the full Kotatsu
+experience using the assets from your Kotatsu forks. The legacy web/PWA remains in maintenance mode only for reference.
 
----
+_Last updated: 2025-11-25 18:24 UTC._
 
-## Phase 1: Web-Based Manga Reader (GitHub Pages)
+## Kotatsu asset inclusion (from all forks)
+Use assets from **every Kotatsu fork** you maintain:
 
-### Milestone 1.1: Project Foundation & Basic UI (Week 1-2)
-- [x] Create project structure
-- [x] Set up HTML/CSS/JavaScript framework
-- [x] Implement responsive Material Design UI
-- [x] Create navigation structure (header, sidebar, main content area)
-- [x] Set up routing for single-page application (SPA)
-- [x] Implement dark/light theme toggle
+- `github.com/swolem12/Kotatsu`
+- `github.com/swolem12/kotatsu-parsers`
+- `github.com/swolem12/kotatsu-syncserver`
+- `github.com/swolem12/kotatsuwebsite`
+- `github.com/swolem12/kotatsu-dl`
+- `github.com/swolem12/kotatsu-dl-gui`
 
-### Milestone 1.2: Manga Catalog & Search (Week 2-3)
-- [x] Create manga listing/grid view
-- [x] Implement search functionality
-- [x] Add filtering by genre, status, rating
-- [x] Create manga detail page
-- [x] Display manga metadata (title, author, description, cover, tags)
-- [ ] Implement pagination for manga lists
+Place them in the Android project as follows:
 
-### Milestone 1.3: Manga Reader Core (Week 3-4)
-- [x] Build manga reader interface
-- [x] Implement page navigation (next/previous)
-- [x] Add keyboard shortcuts (arrow keys, space)
-- [ ] Create reading modes (single page, double page, webtoon/vertical scroll)
-- [ ] Implement zoom and pan controls
-- [ ] Add fullscreen mode
-- [x] Create progress indicator
+- **Branding & launcher**: App icons, adaptive icons, feature graphics, splash/launch screens → `android/app/src/main/res/mipmap*`
+  and `res/drawable*`. Preserve Kotatsu palette, gradients, and accent colors.
+- **Reader UI assets**: Page-turn arrows, gesture hints, page slider thumbs, scrollbar indicators, reading mode icons →
+  `res/drawable` or `res/drawable-anydpi` as VectorDrawables (convert SVGs if needed).
+- **Catalog & library assets**: Placeholder covers, empty-state illustrations, badges, source/service logos (from parser forks),
+  and tag chips → `res/drawable` and `res/values/strings.xml` for labels.
+- **Typography & colors**: Import Kotatsu’s font files (if licensed) or map to equivalent Google Fonts; define the palette in
+  `res/values/colors.xml` and expose them through the Compose theme.
+- **Internationalization**: Reuse Kotatsu string resources from each fork (menu labels, actions, errors) and place them in
+  `res/values/strings.xml` (and locale-specific `values-xx/`).
+- **Data fixtures**: Sample sources/parsers metadata (icons, names) for offline demo state → place JSON/Proto fixtures under
+  `app/src/main/assets/` for bootstrapping before networking is wired.
 
-### Milestone 1.4: Data Source Integration (Week 4-5)
-- [ ] Design API abstraction layer
-- [ ] Implement 1st manga source (MangaDex API)
-- [ ] Implement 2nd manga source (alternative free API)
-- [ ] Add source selection in UI
-- [ ] Implement chapter list fetching
-- [ ] Implement page image loading with caching
-- [ ] Add loading states and error handling
+Track imported assets via `docs/KOTATSU_ASSET_MANIFEST.md` and keep checksums so updates from forks can be re-synced.
 
-### Milestone 1.5: User Features - Favorites & History (Week 5-6)
-- [x] Implement localStorage for data persistence
-- [x] Create favorites/bookmarks system
-- [x] Add "Add to Favorites" functionality
-- [x] Create favorites page/section
-- [x] Implement reading history tracking
-- [x] Create history page
-- [x] Add "Continue Reading" feature
-- [x] Implement bookmark positions within chapters
+## Full operational TODO (Android-first)
+A consolidated, end-to-end checklist to take the native app from scaffold to operational parity with Kotatsu.
 
-### Milestone 1.6: User Features - Library Management (Week 6-7)
-- [ ] Create user library/collection system
-- [ ] Implement custom categories/folders
-- [ ] Add manga to multiple categories
-- [ ] Create category management UI
-- [ ] Implement sorting options (title, last read, date added)
-- [ ] Add bulk actions (move, delete, mark as read)
+### Phase 0 — Asset ingestion & build plumbing
+- [ ] Mirror assets from all Kotatsu forks into the Android `res/` and `assets/` directories (see asset manifest).
+- [ ] Set up Gradle tasks to validate missing drawables/strings against the manifest.
+- [ ] Add baseline tests (unit + screenshot) to catch asset regressions.
 
-### Milestone 1.7: Reader Enhancements (Week 7-8)
-- [ ] Implement reading settings panel
-- [ ] Add brightness control
-- [ ] Add page transition animations
-- [ ] Implement gesture controls (swipe for mobile)
-- [ ] Add chapter selection dropdown in reader
-- [ ] Create reader toolbar (auto-hide)
-- [ ] Implement "mark as read" functionality
-- [ ] Add reading statistics
+### Phase 1 — Platform foundation
+- [x] Initialize Android Studio project with Compose + Material3 scaffold.
+- [x] Apply Kotatsu color system, typography, and shape tokens to the Compose theme.
+- [x] Introduce DI (Hilt) and module structure (app, domain, data, parsers/extensions).
+- [x] Configure Room/Datastore, Retrofit/OkHttp, and coroutine dispatchers.
+- [x] Wire navigation (Navigation Compose) with root destinations (Home, Catalog, Reader, Library, Settings, Downloads).
 
-### Milestone 1.8: Advanced Features (Week 8-9)
-- [ ] Implement updates notification system
-- [ ] Create "New Chapters" feed
-- [ ] Add manga recommendations
-- [ ] Implement filters for recommendations
-- [ ] Create "Popular" and "Trending" sections
-- [ ] Add manga rating/review display
-- [ ] Implement advanced search filters
+### Phase 2 — Catalog & sources
+- [ ] Import source metadata (name, icon, language, NSFW flags) from all parser forks into `assets/`.
+- [x] Implement source list UI with enable/disable, language filters, and pinned sources.
+- [x] Add catalog browsing with pagination, filters, and search tied to sources.
+- [x] Build manga detail screen (metadata, tags, chapters, actions) with source-aware fetching (fixtures for now).
+- [ ] Implement source extension management (install/update/remove) mirroring Kotatsu behavior.
 
-### Milestone 1.9: Offline Support & PWA (Week 9-10)
-- [x] Convert to Progressive Web App (PWA)
-- [x] Implement service worker for caching
-- [x] Add offline reading capability
-- [ ] Create download manager UI
-- [ ] Implement chapter download functionality
-- [ ] Add storage management tools
-- [ ] Create install prompts
+### Phase 3 — Reader core
+- [x] Seed reader route with Compose pager + slider using bundled Kotatsu-inspired chapter fixtures.
+- [ ] Implement image pipeline (network fetch, disk cache, prefetch) with retry/backoff.
+- [ ] Reading modes: single page, double page, webtoon/vertical scroll, with per-manga defaults.
+- [ ] Controls: brightness, orientation lock, zoom/pan, page slider, gestures (tap, swipe, volume keys).
+- [ ] Chapter navigation: previous/next, jump to page, auto next-chapter, and progress persistence.
+- [ ] Offline pages: save-on-open and explicit download for chapters/pages.
 
-### Milestone 1.10: Polish & Optimization (Week 10-11)
-- [ ] Optimize image loading and caching
-- [ ] Implement lazy loading
-- [ ] Add loading skeletons/placeholders
-- [ ] Improve error handling and user feedback
-- [ ] Add accessibility features (ARIA labels, keyboard nav)
-- [ ] Implement analytics (privacy-respecting)
-- [ ] Performance optimization
-- [ ] Cross-browser testing and fixes
+### Phase 4 — Library, history, and tracking
+- [ ] Library shelves/categories with sort (title, last read, date added) and bulk actions.
+- [ ] Favorites/bookmarks with pinned state and quick filters.
+- [ ] Reading history with resume, clear, and per-source scoping.
+- [ ] External trackers: integrate AniList/MyAnimeList/Kitsu/Shikimori with two-way status sync.
 
-### Milestone 1.11: Additional Sources (Week 11-12)
-- [ ] Implement 3rd manga source
-- [ ] Implement 4th manga source
-- [ ] Implement 5th manga source
-- [ ] Create source management UI
-- [ ] Add source enable/disable functionality
-- [ ] Implement source priority settings
+### Phase 5 — Downloads & filesystem
+- [ ] End-to-end download manager (queue, pause/resume, retries) with notifications and constraints. _(Skeleton UI + fixture queue wired; worker + notification plumbing pending.)_
+- [ ] CBZ/CBR/ZIP/EPUB importer with media scanning and cover extraction.
+- [ ] Storage/quota UI with delete, move, and “optimize storage” actions.
 
----
+### Phase 6 — Account, backup, and sync
+- [ ] Optional account sign-in for cloud backup/sync of library, history, and settings.
+- [ ] Local backup/restore (Room export + assets + preferences) with encryption option.
+- [ ] Migration path from web/PWA data (IndexedDB/localStorage export → Room import tool).
 
-## Phase 2: Enhanced Web Features (Months 4-5)
+### Phase 7 — UX polish and release readiness
+- [ ] Material You dynamic color, edge-to-edge, motion/easing parity with Kotatsu.
+- [ ] Accessibility: TalkBack labels, large text, contrast, and gesture alternatives.
+- [ ] Crash/error surfaces, empty/zero states using imported illustrations.
+- [ ] QA on phones/tablets, wide screens, and low-memory devices; fix ANRs and jank.
+- [ ] App bundles/APK signing pipeline, GitHub Releases, and F-Droid build.
+- [ ] Store listings: feature graphics, screenshots (built from imported assets), and changelog cadence.
 
-### Milestone 2.1: User Accounts & Sync (Optional Cloud Features)
-- [ ] Design authentication system (Firebase/Supabase)
-- [ ] Implement user registration/login
-- [ ] Add cloud sync for favorites and history
-- [ ] Implement cross-device synchronization
-- [ ] Create account management UI
-- [ ] Add data export/import functionality
-
-### Milestone 2.2: Social Features
-- [ ] Implement user profiles
-- [ ] Add manga lists sharing
-- [ ] Create reading lists/collections
-- [ ] Implement comments/discussions (optional)
-- [ ] Add recommendation sharing
-
-### Milestone 2.3: Advanced Reader Features
-- [ ] Implement page pre-loading
-- [ ] Add reading speed statistics
-- [ ] Create custom reading modes
-- [ ] Implement color filter overlays
-- [ ] Add page bookmarking with notes
-- [ ] Implement text-to-speech for text-heavy manga (experimental)
-
-### Milestone 2.4: Integration Features
-- [ ] Implement Shikimori integration
-- [ ] Implement AniList integration
-- [ ] Implement MyAnimeList integration
-- [ ] Implement Kitsu integration
-- [ ] Add sync status tracking
-- [ ] Create integration settings UI
-
----
-
-## Phase 3: Android Native Application (Months 6-12)
-
-### Milestone 3.1: Android Project Setup
-- [ ] Set up Android Studio project
-- [ ] Configure Kotlin and Gradle
-- [ ] Implement Material You design
-- [ ] Set up dependency injection (Hilt)
-- [ ] Configure Room database
-- [ ] Set up multi-module architecture
-
-### Milestone 3.2: Core Android Features
-- [ ] Port web UI to Android native
-- [ ] Implement navigation component
-- [ ] Create fragments for main screens
-- [ ] Implement Android reader with gestures
-- [ ] Add notification support
-- [ ] Implement background updates
-
-### Milestone 3.3: Android-Specific Features
-- [ ] Implement file system downloads
-- [ ] Add CBZ/CBR file support
-- [ ] Create Android widgets
-- [ ] Implement app shortcuts
-- [ ] Add biometric authentication
-- [ ] Implement system dark mode integration
-
-### Milestone 3.4: Data Migration & Sync
-- [ ] Create web-to-Android data migration tool
-- [ ] Implement cloud sync between web and Android
-- [ ] Add backup/restore functionality
-- [ ] Create settings sync
-
-### Milestone 3.5: Performance & Optimization
-- [ ] Optimize for Android 6.0+ support
-- [ ] Implement battery optimization
-- [ ] Add memory management
-- [ ] Optimize for tablets
-- [ ] Test on various devices
-
-### Milestone 3.6: Publishing
-- [ ] Prepare app for release
-- [ ] Create F-Droid build
-- [ ] Create GitHub releases
-- [ ] Write documentation
-- [ ] Create user guides
-
----
-
-## Technical Stack
-
-### Phase 1 (Web)
-- **Frontend**: HTML5, CSS3, JavaScript (ES6+)
-- **Framework**: Vanilla JS or lightweight framework (Alpine.js/Petite Vue)
-- **UI**: Material Design Components (MDC Web)
-- **Build**: Vite or Parcel
-- **Storage**: localStorage, IndexedDB
-- **PWA**: Workbox for service workers
-- **Hosting**: GitHub Pages
-
-### Phase 2 (Enhanced Web)
-- **Backend** (Optional): Firebase/Supabase for auth & sync
-- **APIs**: REST APIs from manga sources
-- **Integration**: OAuth for tracking services
-
-### Phase 3 (Android)
-- **Language**: Kotlin
-- **Architecture**: MVVM, Clean Architecture
-- **DI**: Hilt
-- **Database**: Room
-- **Network**: Retrofit, OkHttp
-- **Image Loading**: Coil
-- **Async**: Coroutines, Flow
-- **UI**: Jetpack Compose / Material You
-- **Build**: Gradle with Kotlin DSL
-
----
-
-## Manga Sources to Implement
-
-### Priority 1 (Phase 1)
-1. MangaDex (Free API, large catalog)
-2. MangaSee/MangaLife (Free, no API key needed)
-
-### Priority 2 (Phase 1 later)
-3. Comick.io
-4. Batoto
-5. MangaKakalot
-
-### Priority 3 (Phase 2)
-6-20. Additional sources as needed (targeting 20+ sources for web version)
-
-### Phase 3
-Continue expanding to 100+ sources for Android version
-
----
-
-## Success Metrics
-
-### Phase 1
-- Functional web reader with 2+ manga sources
-- Responsive design (mobile, tablet, desktop)
-- Favorites and history working
-- Offline reading via PWA
-- Deployable to GitHub Pages
-
-### Phase 2
-- 5+ manga sources
-- User accounts and sync
-- Tracking service integrations
-- Enhanced reader features
-
-### Phase 3
-- Native Android app published
-- 100+ manga sources
-- Feature parity with original Chirui Reader
-- Active user base
-
----
-
-## Current Status
-
-**Phase**: 1 (Web-Based Manga Reader)  
-**Milestone**: 1.1 (Project Foundation & Basic UI)  
-**Progress**: Starting - creating project structure
-
-**Next Steps**:
-1. Set up basic HTML/CSS/JS structure
-2. Implement Material Design UI framework
-3. Create responsive navigation
-4. Build manga catalog view
-5. Integrate first manga source (MangaDex)
-
----
-
-## Notes
-
-- This roadmap is flexible and will be adjusted based on progress and feedback
-- Each milestone can be broken down into smaller tasks
-- Features will be implemented incrementally and tested thoroughly
-- Focus on core functionality first, polish later
-- Maintain clean, documented code throughout
-- Regular commits and version tracking
+## Maintenance of the legacy web/PWA (reference only)
+The web PWA remains available for demos but receives no new feature work. Keep it functional (bug/security fixes only) until the
+Android app reaches parity and replaces it for end users.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy to GitHub Pages](https://github.com/swolem12/Chirui-Reader/actions/workflows/deploy.yml/badge.svg)](https://github.com/swolem12/Chirui-Reader/actions/workflows/deploy.yml)
 
-A web-based manga/manhwa reader application deployable to GitHub Pages.
+Chirui Reader is transitioning from a web-based prototype to a native Kotlin Android application inspired by the Kotatsu reader. _Status last updated: 2025-11-25 18:24 UTC._
 
 ## 🌐 Live Demo
 
@@ -10,7 +10,7 @@ A web-based manga/manhwa reader application deployable to GitHub Pages.
 
 ## What is This?
 
-Chirui Reader is a **Progressive Web App (PWA)** for reading manga and manhwa. It's an **end-user application**, not an SDK or library.
+Chirui Reader started as a **Progressive Web App (PWA)** for reading manga and manhwa. We are now prioritizing the **Android-native** implementation to mirror Kotatsu more closely. It's an **end-user application**, not an SDK or library.
 
 - ✅ Web application for reading manga
 - ✅ Deployed via GitHub Pages
@@ -19,54 +19,42 @@ Chirui Reader is a **Progressive Web App (PWA)** for reading manga and manhwa. I
 - ❌ NOT an SDK or library for developers
 - ❌ NOT a converter or build tool
 
-## Features
+## Tracks
 
-### Core Features
-- 📚 **Manga Catalog** - Browse and search through manga collection
-- 🔍 **Advanced Filtering** - Filter by genre, status, rating
-- 📖 **Manga Reader** - Smooth reading experience with keyboard shortcuts
-- ⌨️ **Keyboard Navigation** - Arrow keys, space bar for page navigation
-- ♥️ **Favorites System** - Save your favorite manga for quick access
-- 📚 **Reading History** - Automatic tracking of reading progress
-- 🔄 **Continue Reading** - Pick up where you left off
+### Native Android (primary focus)
+- Jetpack Compose scaffold in `android/` with Material 3 theme.
+- Kotlin/Gradle setup ready for Kotatsu feature parity work.
+- Catalog experience with a Discover grid (search, filters, pagination) backed by bundled Kotatsu fixtures and a Sources tab with enable/disable toggles.
+- Manga detail view with favorites/actions wired into a basic reader that supports swiping through bundled Kotatsu-inspired pages.
+- Downloads queue skeleton with fixture-backed statuses and controls for pause/resume/cancel/retry.
 
-### PWA Features
-- 💾 **Offline Support** - Read manga even without internet
-- 📱 **Installable** - Add to home screen on mobile/desktop
-- 🌙 **Dark Mode** - Easy on the eyes theme toggle
-- 📱 **Responsive Design** - Works on phones, tablets, and desktops
+### Web prototype (maintenance only)
+- HTML/JS/CSS PWA remains for reference and quick demos.
 
 ## Quick Start
 
-### For Users
-
-1. Visit **[https://swolem12.github.io/Chirui-Reader/](https://swolem12.github.io/Chirui-Reader/)**
-2. Browse the catalog or search for manga
-3. Click on a manga to view details
-4. Start reading!
-5. (Optional) Install as PWA for offline access
-
-### For Developers
-
+### Android app (primary)
 1. Clone this repository
    ```bash
    git clone https://github.com/swolem12/Chirui-Reader.git
-   cd Chirui-Reader
+   cd Chirui-Reader/android
    ```
+2. Open the `android/` folder in Android Studio Hedgehog or later.
+3. Let the IDE download the Android Gradle Plugin and Android 34 SDK.
+4. Run the `app` configuration on a connected device/emulator.
 
-2. Open `index.html` in your browser, or start a local server:
+### Web PWA (legacy prototype)
+1. Clone this repository and install dependencies
    ```bash
-   # Using Python
-   python -m http.server 8000
-   
-   # Using Node.js
-   npx serve .
-   
-   # Using PHP
-   php -S localhost:8000
+   git clone https://github.com/swolem12/Chirui-Reader.git
+   cd Chirui-Reader
+   npm install
    ```
-
-3. Visit `http://localhost:8000`
+2. Run the development server
+   ```bash
+   npm run dev
+   ```
+3. Open the served URL from the CLI output.
 
 ## Documentation
 
@@ -74,9 +62,12 @@ Chirui Reader is a **Progressive Web App (PWA)** for reading manga and manhwa. I
 - 📦 **[docs/DISTRIBUTION.md](docs/DISTRIBUTION.md)** - How to distribute web apps (PWA) vs native Android apps
 - 🚀 **[docs/PWA_QUICK_START.md](docs/PWA_QUICK_START.md)** - Quick guide to implement PWA features
 - 🔍 **[docs/KOTATSU_CLARIFICATION.md](docs/KOTATSU_CLARIFICATION.md)** - Clarifies Kotatsu's architecture (no PWA conversion)
+- 🖼️ **[docs/KOTATSU_ASSET_MANIFEST.md](docs/KOTATSU_ASSET_MANIFEST.md)** - Inventory of Kotatsu fork assets to ingest into the Android app
+- ✅ **[docs/NEXT_STEPS_TODO.md](docs/NEXT_STEPS_TODO.md)** - Approval-focused TODO list for the Android-native Kotatsu build
 - 📋 **[docs/FAQ.md](docs/FAQ.md)** - Frequently asked questions
 - 🗺️ **[CHIRUI_ROADMAP.md](CHIRUI_ROADMAP.md)** - Project roadmap and milestones
 - 💻 **[DEVELOPMENT.md](DEVELOPMENT.md)** - Development guide and deployment instructions
+- 📱 **[android/README.md](android/README.md)** - Native Android project overview and next steps
 
 ## Technology Stack
 
@@ -90,14 +81,15 @@ Chirui Reader is a **Progressive Web App (PWA)** for reading manga and manhwa. I
 
 ## Project Status
 
-**Current Phase**: Phase 1 - Web-Based Manga Reader
+**Current Phase**: Transitioning into Phase 3 - Android Native Application (scaffolding started)
 
-### Completed Milestones
-- ✅ Milestone 1.1: Project Foundation & Basic UI (100%)
-- ✅ Milestone 1.2: Manga Catalog & Search (83%)
-- ✅ Milestone 1.3: Manga Reader Core (57%)
-- ✅ Milestone 1.5: User Features - Favorites & History (100%)
-- ✅ Milestone 1.9: Offline Support & PWA (43%)
+### Recent progress
+- ✅ Android Jetpack Compose skeleton added under `android/`.
+- ✅ Kotlin/Gradle configuration prepared for Kotatsu parity work.
+- ✅ Catalog Discover tab with paginated grid, filters, and offline fixtures plus a Sources tab with language filters and toggles backed by an asset parser registry.
+- ✅ Manga detail screen with bundled Kotatsu-inspired chapter fixtures and in-app favorite toggles.
+- ✅ Download queue screen seeded with Kotatsu-inspired fixture states and controls for pause/resume/cancel/retry (network/worker plumbing pending).
+- ⚠️ Web PWA remains available but is in maintenance-only mode.
 
 See [CHIRUI_ROADMAP.md](CHIRUI_ROADMAP.md) for complete roadmap.
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,23 @@
+# Chirui Reader Android (Kotatsu-native)
+
+This directory contains the initial Android application scaffold for the native Kotlin rewrite of Chirui Reader, targeting feature parity with the Kotatsu fork. _Last updated: 2025-11-25 18:24 UTC._
+
+## Project structure
+- `app/`: UI shell with Jetpack Compose, Material 3 theme, and Hilt entry points. Includes a Catalog experience with a Discover grid (search, filters, pagination), a Sources tab for enable/disable toggles and language filters, a Manga detail screen powered by bundled fixtures, a fixture-backed reader route, and a downloads queue skeleton with pause/resume/cancel/retry controls.
+- `domain/`: platform-agnostic models and coroutine dispatcher qualifiers.
+- `data/`: DI modules for Room, Retrofit/OkHttp, Datastore, dispatcher provider, and parser bindings plus an asset-backed parser registry.
+- `parsers/`: interface for the parser registry and a static fallback implementation.
+- `MainActivity`: Compose entry point with a top app bar and bottom navigation across Home, Catalog, Library, Downloads, and Settings.
+- `ui/theme`: lightweight theme wrapper that will be expanded as screens are built.
+
+## Getting started
+1. Open the `android/` directory in Android Studio Hedgehog or later.
+2. Let Android Studio download the Android Gradle Plugin and SDK platform 34.
+3. Connect a device or start an emulator, then run the `app` configuration.
+
+### Next steps
+- Replace the placeholder parser registry JSON with the full set of Kotatsu source assets/icons and wire icons into the UI.
+- Swap the bundled catalog fixture (`assets/catalog/featured.json`) with real covers/titles from the Kotatsu forks.
+- Port Kotatsu domain models, repositories, and data sources into Kotlin packages across `domain/` and `data/`.
+- Wire real download workers, notifications, and storage plumbing behind the new downloads queue skeleton, replacing fixture data with assets from your Kotatsu forks.
+- Use **docs/NEXT_STEPS_TODO.md** as the approval checklist for sprint-by-sprint deliverables.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,97 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.kapt")
+    id("com.google.dagger.hilt.android")
+}
+
+android {
+    namespace = "com.chirui.reader"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.chirui.reader"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "0.1.0"
+
+        vectorDrawables { useSupportLibrary = true }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.11"
+    }
+
+    packaging {
+        resources.excludes.add("/META-INF/{AL2.0,LGPL2.1}")
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.04.01")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation(project(":domain"))
+    implementation(project(":data"))
+    implementation(project(":parsers"))
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.3")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.3")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation("io.coil-kt:coil-compose:2.7.0")
+
+    implementation("com.google.dagger:hilt-android:2.51.1")
+    kapt("com.google.dagger:hilt-compiler:2.51.1")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}
+
+kapt {
+    correctErrorTypes = true
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,8 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /usr/local/android-sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the proguardFiles
+# directive in build.gradle.kts.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:name=".ChiruiReaderApp"
+        android:label="Chirui Reader"
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:roundIcon="@android:drawable/sym_def_app_icon"
+        android:allowBackup="true"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.ChiruiReader">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+            android:windowSoftInputMode="stateHidden">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+    </application>
+</manifest>

--- a/android/app/src/main/assets/catalog/details.json
+++ b/android/app/src/main/assets/catalog/details.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "mangadex-blue-flag",
+    "title": "Blue Flag",
+    "sourceId": "mangadex",
+    "sourceName": "MangaDex",
+    "language": "en",
+    "nsfw": false,
+    "status": "completed",
+    "tags": ["drama", "romance", "school"],
+    "description": "Three friends navigate love and identity in a grounded coming-of-age story.",
+    "author": "KAITO",
+    "artist": "KAITO",
+    "sourceUrl": "https://mangadex.org/title/blue-flag",
+    "favorite": true,
+    "chapters": [
+      { "id": "bf-1", "title": "Spring Sunlight", "number": 1.0, "downloaded": true, "readProgress": 1.0 },
+      { "id": "bf-2", "title": "Shadows", "number": 2.0, "downloaded": false, "readProgress": 0.25 },
+      { "id": "bf-3", "title": "Footsteps", "number": 3.0 }
+    ]
+  },
+  {
+    "id": "mangasee-solo-leveling",
+    "title": "Solo Leveling",
+    "sourceId": "mangasee",
+    "sourceName": "MangaSee",
+    "language": "en",
+    "nsfw": false,
+    "status": "completed",
+    "tags": ["action", "fantasy", "dungeon"],
+    "description": "Sung Jinwoo climbs from the weakest hunter to an unrivaled shadow monarch.",
+    "author": "Chugong",
+    "artist": "DUBU",
+    "sourceUrl": "https://mangasee123.com/manga/Solo-Leveling",
+    "favorite": false,
+    "chapters": [
+      { "id": "sl-178", "title": "Journey's End", "number": 178.0, "downloaded": true, "readProgress": 1.0 },
+      { "id": "sl-177", "title": "Shadow Monarch", "number": 177.0, "downloaded": true, "readProgress": 1.0 },
+      { "id": "sl-1", "title": "Weak Hunter", "number": 1.0, "downloaded": false, "readProgress": 0.0 }
+    ]
+  },
+  {
+    "id": "comicwalker-frieren",
+    "title": "Frieren: Beyond Journey's End",
+    "sourceId": "comicwalker",
+    "sourceName": "ComicWalker",
+    "language": "ja",
+    "nsfw": false,
+    "status": "ongoing",
+    "tags": ["fantasy", "adventure"],
+    "description": "An elf mage retraces her party's path to understand the meaning of their decade together.",
+    "author": "Kanehito Yamada",
+    "artist": "Tsukasa Abe",
+    "sourceUrl": "https://comic-walker.com/frieren",
+    "favorite": false,
+    "chapters": [
+      { "id": "fr-110", "title": "Starry Village", "number": 110.0, "downloaded": false, "readProgress": 0.0 },
+      { "id": "fr-12", "title": "Mage Exam", "number": 12.0, "downloaded": false, "readProgress": 0.0 },
+      { "id": "fr-1", "title": "Departure", "number": 1.0, "downloaded": false, "readProgress": 1.0 }
+    ]
+  },
+  {
+    "id": "nhentai-scarlet-memories",
+    "title": "Scarlet Memories",
+    "sourceId": "nhentai",
+    "sourceName": "NHentai",
+    "language": "en",
+    "nsfw": true,
+    "status": "completed",
+    "tags": ["doujinshi", "vampire"],
+    "description": "Mature, redacted sample entry for NSFW badge validation and filtering.",
+    "author": "Sample Circle",
+    "artist": "Sample Artist",
+    "sourceUrl": "https://nhentai.net/g/000000",
+    "favorite": false,
+    "chapters": [
+      { "id": "sm-1", "title": "Scarlet", "number": 1.0, "downloaded": false, "readProgress": 0.5 }
+    ]
+  },
+  {
+    "id": "manganato-vinland-saga",
+    "title": "Vinland Saga",
+    "sourceId": "manganato",
+    "sourceName": "Manganato",
+    "language": "en",
+    "nsfw": false,
+    "status": "ongoing",
+    "tags": ["historical", "drama", "seinen"],
+    "description": "A vengeful warrior seeks a new purpose in a brutal Viking-era epic.",
+    "author": "Makoto Yukimura",
+    "artist": "Makoto Yukimura",
+    "sourceUrl": "https://manganato.com/vinland-saga",
+    "favorite": false,
+    "chapters": [
+      { "id": "vs-200", "title": "Path Home", "number": 200.0, "downloaded": false, "readProgress": 0.0 },
+      { "id": "vs-1", "title": "The End of the Prologue", "number": 1.0, "downloaded": true, "readProgress": 1.0 }
+    ]
+  }
+]

--- a/android/app/src/main/assets/catalog/featured.json
+++ b/android/app/src/main/assets/catalog/featured.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "mangadex-blue-flag",
+    "title": "Blue Flag",
+    "sourceId": "mangadex",
+    "sourceName": "MangaDex",
+    "language": "en",
+    "coverUrl": null,
+    "nsfw": false,
+    "status": "completed",
+    "tags": ["drama", "romance", "school"],
+    "description": "A grounded ensemble drama used to validate tagging and multi-language metadata."
+  },
+  {
+    "id": "mangasee-solo-leveling",
+    "title": "Solo Leveling",
+    "sourceId": "mangasee",
+    "sourceName": "MangaSee",
+    "language": "en",
+    "coverUrl": null,
+    "nsfw": false,
+    "status": "completed",
+    "tags": ["action", "fantasy", "dungeon"]
+  },
+  {
+    "id": "comicwalker-frieren",
+    "title": "Frieren: Beyond Journey's End",
+    "sourceId": "comicwalker",
+    "sourceName": "ComicWalker",
+    "language": "ja",
+    "coverUrl": null,
+    "nsfw": false,
+    "status": "ongoing",
+    "tags": ["fantasy", "adventure"],
+    "description": "Japanese catalog entry to exercise right-to-left layout and source badges."
+  },
+  {
+    "id": "nhentai-scarlet-memories",
+    "title": "Scarlet Memories",
+    "sourceId": "nhentai",
+    "sourceName": "nhentai",
+    "language": "en",
+    "coverUrl": null,
+    "nsfw": true,
+    "status": "completed",
+    "tags": ["doujinshi", "nsfw"],
+    "description": "Explicit sample from Kotatsu's doujin lane; surfaces NSFW labeling."
+  },
+  {
+    "id": "manganato-kaiju-no-8",
+    "title": "Kaiju No. 8",
+    "sourceId": "manganato",
+    "sourceName": "Manganato",
+    "language": "en",
+    "coverUrl": null,
+    "nsfw": false,
+    "status": "ongoing",
+    "tags": ["action", "monsters", "shonen"]
+  },
+  {
+    "id": "mangadex-es-chainsaw-man",
+    "title": "Chainsaw Man",
+    "sourceId": "mangadex-es",
+    "sourceName": "MangaDex Español",
+    "language": "es",
+    "coverUrl": null,
+    "nsfw": true,
+    "status": "ongoing",
+    "tags": ["action", "horror"],
+    "description": "Spanish lane entry validating locale chips and NSFW overlap."
+  },
+  {
+    "id": "mangadex-oishinbo",
+    "title": "Oishinbo",
+    "sourceId": "mangadex",
+    "sourceName": "MangaDex",
+    "language": "en",
+    "coverUrl": null,
+    "nsfw": false,
+    "status": "completed",
+    "tags": ["cooking", "slice of life"],
+    "description": "Classic catalog sample to exercise pagination and tags."
+  },
+  {
+    "id": "mangadex-yotsuba",
+    "title": "Yotsuba&!",
+    "sourceId": "mangadex",
+    "sourceName": "MangaDex",
+    "language": "en",
+    "coverUrl": null,
+    "nsfw": false,
+    "status": "ongoing",
+    "tags": ["comedy", "slice of life"]
+  },
+  {
+    "id": "mangadex-blue-period",
+    "title": "Blue Period",
+    "sourceId": "mangadex",
+    "sourceName": "MangaDex",
+    "language": "multi",
+    "coverUrl": null,
+    "nsfw": false,
+    "status": "ongoing",
+    "tags": ["art", "drama"]
+  },
+  {
+    "id": "manganato-spy-x-family",
+    "title": "Spy x Family",
+    "sourceId": "manganato",
+    "sourceName": "Manganato",
+    "language": "en",
+    "coverUrl": null,
+    "nsfw": false,
+    "status": "ongoing",
+    "tags": ["comedy", "spy", "family"]
+  }
+]

--- a/android/app/src/main/assets/downloads/queue.json
+++ b/android/app/src/main/assets/downloads/queue.json
@@ -1,0 +1,53 @@
+{
+  "downloads": [
+    {
+      "id": "dl-001",
+      "title": "Blue Fire Vol. 1",
+      "source": "MangaDex",
+      "coverUrl": null,
+      "status": "DOWNLOADING",
+      "progress": 0.42,
+      "etaMinutes": 5,
+      "sizeLabel": "128 MB",
+      "chapters": [
+        { "id": "c1", "name": "Ch. 1 - Spark", "progress": 1.0 },
+        { "id": "c2", "name": "Ch. 2 - Ember", "progress": 0.38 }
+      ]
+    },
+    {
+      "id": "dl-002",
+      "title": "Skybound Chapter Pack",
+      "source": "Mangasee",
+      "coverUrl": null,
+      "status": "PAUSED",
+      "progress": 0.15,
+      "etaMinutes": 18,
+      "sizeLabel": "64 MB",
+      "chapters": [
+        { "id": "c10", "name": "Ch. 10 - Drift", "progress": 0.15 }
+      ]
+    },
+    {
+      "id": "dl-003",
+      "title": "Kotatsu Showcase Bundle",
+      "source": "Kotatsu-dl",
+      "coverUrl": null,
+      "status": "FAILED",
+      "progress": 0.6,
+      "etaMinutes": null,
+      "sizeLabel": "42 MB",
+      "chapters": []
+    },
+    {
+      "id": "dl-004",
+      "title": "Archive Import",
+      "source": "CBZ/Local",
+      "coverUrl": null,
+      "status": "COMPLETED",
+      "progress": 1.0,
+      "etaMinutes": null,
+      "sizeLabel": "215 MB",
+      "chapters": []
+    }
+  ]
+}

--- a/android/app/src/main/assets/reader/chapters.json
+++ b/android/app/src/main/assets/reader/chapters.json
@@ -1,0 +1,50 @@
+{
+  "chapters": [
+    {
+      "chapterId": "bf-1",
+      "mangaId": "mangadex-blue-flag",
+      "mangaTitle": "Blue Flag",
+      "chapterTitle": "Spring Sunlight",
+      "pages": [
+        { "index": 1, "imageUrl": "https://picsum.photos/seed/bf1-1/900/1300" },
+        { "index": 2, "imageUrl": "https://picsum.photos/seed/bf1-2/900/1300" },
+        { "index": 3, "imageUrl": "https://picsum.photos/seed/bf1-3/900/1300" },
+        { "index": 4, "imageUrl": "https://picsum.photos/seed/bf1-4/900/1300" }
+      ]
+    },
+    {
+      "chapterId": "sl-178",
+      "mangaId": "mangasee-solo-leveling",
+      "mangaTitle": "Solo Leveling",
+      "chapterTitle": "Journey's End",
+      "pages": [
+        { "index": 1, "imageUrl": "https://picsum.photos/seed/sl178-1/1080/1600" },
+        { "index": 2, "imageUrl": "https://picsum.photos/seed/sl178-2/1080/1600" },
+        { "index": 3, "imageUrl": "https://picsum.photos/seed/sl178-3/1080/1600" },
+        { "index": 4, "imageUrl": "https://picsum.photos/seed/sl178-4/1080/1600" }
+      ]
+    },
+    {
+      "chapterId": "fr-1",
+      "mangaId": "comicwalker-frieren",
+      "mangaTitle": "Frieren: Beyond Journey's End",
+      "chapterTitle": "Departure",
+      "pages": [
+        { "index": 1, "imageUrl": "https://picsum.photos/seed/fr1-1/980/1500" },
+        { "index": 2, "imageUrl": "https://picsum.photos/seed/fr1-2/980/1500" },
+        { "index": 3, "imageUrl": "https://picsum.photos/seed/fr1-3/980/1500" }
+      ]
+    },
+    {
+      "chapterId": "sm-1",
+      "mangaId": "nhentai-scarlet-memories",
+      "mangaTitle": "Scarlet Memories",
+      "chapterTitle": "Scarlet",
+      "pages": [
+        { "index": 1, "imageUrl": "https://picsum.photos/seed/sm1-1/900/1300" },
+        { "index": 2, "imageUrl": "https://picsum.photos/seed/sm1-2/900/1300" },
+        { "index": 3, "imageUrl": "https://picsum.photos/seed/sm1-3/900/1300" }
+      ]
+    }
+  ]
+}

--- a/android/app/src/main/assets/sources/sources.json
+++ b/android/app/src/main/assets/sources/sources.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "mangadex",
+    "name": "MangaDex",
+    "language": "multi",
+    "description": "Global multi-language catalog drawn from Kotatsu parsers.",
+    "nsfw": false,
+    "iconPath": null
+  },
+  {
+    "id": "mangasee",
+    "name": "MangaSee",
+    "language": "en",
+    "description": "English catalog with fast updates from Kotatsu's parser set.",
+    "nsfw": false,
+    "iconPath": null
+  },
+  {
+    "id": "nhentai",
+    "name": "nhentai",
+    "language": "en",
+    "description": "Doujin source used in Kotatsu for reader feature parity.",
+    "nsfw": true,
+    "iconPath": null
+  },
+  {
+    "id": "comicwalker",
+    "name": "ComicWalker",
+    "language": "ja",
+    "description": "Japanese catalog for native-right-to-left reading tests.",
+    "nsfw": false,
+    "iconPath": null
+  },
+  {
+    "id": "manganato",
+    "name": "Manganato",
+    "language": "en",
+    "description": "Kotatsu parser staple for shonen/shoujo libraries.",
+    "nsfw": false,
+    "iconPath": null
+  },
+  {
+    "id": "mangadex-es",
+    "name": "MangaDex Español",
+    "language": "es",
+    "description": "Spanish lane to validate multi-locale UI flows.",
+    "nsfw": false,
+    "iconPath": null
+  }
+]

--- a/android/app/src/main/java/com/chirui/reader/ChiruiReaderApp.kt
+++ b/android/app/src/main/java/com/chirui/reader/ChiruiReaderApp.kt
@@ -1,0 +1,7 @@
+package com.chirui.reader
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class ChiruiReaderApp : Application()

--- a/android/app/src/main/java/com/chirui/reader/MainActivity.kt
+++ b/android/app/src/main/java/com/chirui/reader/MainActivity.kt
@@ -1,0 +1,331 @@
+package com.chirui.reader
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.LibraryBooks
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavDestination
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.chirui.reader.catalog.CatalogScreen
+import com.chirui.reader.catalog.MangaDetailScreen
+import com.chirui.reader.downloads.DownloadsScreen
+import com.chirui.reader.reader.ReaderScreen
+import com.chirui.reader.ui.theme.ChiruiReaderTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ChiruiReaderTheme {
+                ChiruiReaderApp()
+            }
+        }
+    }
+}
+
+private data class TopLevelDestination(
+    val route: String,
+    val label: String,
+    val description: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val title: String,
+)
+
+private val destinations = listOf(
+    TopLevelDestination(
+        route = "home",
+        label = "Home",
+        description = "Welcome and status",
+        icon = Icons.Filled.Home,
+        title = "Home",
+    ),
+    TopLevelDestination(
+        route = "catalog",
+        label = "Catalog",
+        description = "Discover sources and manga",
+        icon = Icons.Filled.LibraryBooks,
+        title = "Catalog",
+    ),
+    TopLevelDestination(
+        route = "library",
+        label = "Library",
+        description = "Saved and favorites",
+        icon = Icons.Filled.Bookmarks,
+        title = "Library",
+    ),
+    TopLevelDestination(
+        route = "downloads",
+        label = "Downloads",
+        description = "Offline chapters and queue",
+        icon = Icons.Filled.Sync,
+        title = "Downloads",
+    ),
+    TopLevelDestination(
+        route = "settings",
+        label = "Settings",
+        description = "App preferences",
+        icon = Icons.Filled.Settings,
+        title = "Settings",
+    )
+)
+
+@Composable
+fun ChiruiReaderApp() {
+    val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+    val activeDestination = destinations.firstOrNull { currentDestination.isOnDestination(it.route) }
+    val isCatalogDetail = currentDestination?.route?.startsWith("catalog/detail/") == true
+
+    Scaffold(
+        topBar = {
+            when {
+                isCatalogDetail -> {
+                    CenterAlignedTopAppBar(
+                        title = { Text("Manga") },
+                        navigationIcon = {
+                            IconButton(onClick = { navController.popBackStack() }) {
+                                Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+                            }
+                        }
+                    )
+                }
+                activeDestination != null -> {
+                    CenterAlignedTopAppBar(title = { Text(activeDestination.title) })
+                }
+            }
+        },
+        bottomBar = {
+            NavigationBar(containerColor = MaterialTheme.colorScheme.surface) {
+                destinations.forEach { destination ->
+                    val selected = currentDestination.isOnDestination(destination.route)
+                    NavigationBarItem(
+                        selected = selected,
+                        onClick = {
+                            navController.navigate(destination.route) {
+                                popUpTo(navController.graph.findStartDestination().id) {
+                                    saveState = true
+                                }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
+                        icon = {
+                            androidx.compose.material3.Icon(
+                                imageVector = destination.icon,
+                                contentDescription = destination.description
+                            )
+                        },
+                        label = { Text(destination.label) },
+                        colors = NavigationBarItemDefaults.colors(
+                            selectedIconColor = MaterialTheme.colorScheme.onPrimary,
+                            selectedTextColor = MaterialTheme.colorScheme.onPrimary,
+                            indicatorColor = MaterialTheme.colorScheme.primary,
+                            unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    )
+                }
+            }
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = destinations.first().route,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable("home") { StatusScreen() }
+            composable("catalog") {
+                CatalogScreen(onOpenManga = { mangaId ->
+                    navController.navigate("catalog/detail/$mangaId")
+                })
+            }
+            composable("library") { LibraryScreen() }
+            composable("downloads") { DownloadsScreen() }
+            composable("settings") { SettingsScreen() }
+            composable(
+                route = "catalog/detail/{mangaId}",
+                arguments = listOf(navArgument("mangaId") { type = NavType.StringType })
+            ) {
+                MangaDetailScreen(
+                    onShare = { /* share sheet placeholder */ },
+                    onOpenChapter = { chapter ->
+                        navController.navigate("reader/${chapter.id}")
+                    }
+                )
+            }
+            composable(
+                route = "reader/{chapterId}",
+                arguments = listOf(navArgument("chapterId") { type = NavType.StringType })
+            ) {
+                ReaderScreen(
+                    onBack = { navController.popBackStack() },
+                    onShare = { /* share hook placeholder */ },
+                    onDownload = { /* download hook placeholder */ },
+                )
+            }
+        }
+    }
+}
+
+private fun NavDestination?.isOnDestination(route: String): Boolean {
+    val destinationRoute = this?.route ?: return false
+    return destinationRoute == route || destinationRoute.startsWith("$route/")
+}
+
+@Composable
+private fun StatusScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Text(
+            text = "Chirui Reader",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = "Kotatsu-native foundation is ready. Use this shell to hook up data, sources, and reader modules.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        InfoCard(
+            title = "Next step",
+            body = "Hook real download workers + parser assets to replace the fixture queue and source registry.",
+            accent = MaterialTheme.colorScheme.primary
+        )
+        InfoCard(
+            title = "Catalog",
+            body = "Source list is live with enable/disable toggles and language filters for Kotatsu parsers.",
+            accent = MaterialTheme.colorScheme.secondary
+        )
+    }
+}
+
+@Composable
+private fun LibraryScreen() {
+    PlaceholderScreen(
+        title = "Library",
+        message = "Favorites, categories, and reading history will live here.",
+        chip = "Shelves"
+    )
+}
+
+@Composable
+private fun SettingsScreen() {
+    PlaceholderScreen(
+        title = "Settings",
+        message = "Appearance, reader defaults, and network/extension options will be configurable here.",
+        chip = "Preferences"
+    )
+}
+
+@Composable
+private fun PlaceholderScreen(title: String, message: String, chip: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = message,
+            modifier = Modifier.padding(top = 12.dp),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(18.dp))
+        Chip(text = chip)
+    }
+}
+
+@Composable
+private fun Chip(text: String) {
+    androidx.compose.material3.Surface(
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        shape = MaterialTheme.shapes.small
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            style = MaterialTheme.typography.labelLarge
+        )
+    }
+}
+
+@Composable
+private fun InfoCard(title: String, body: String, accent: androidx.compose.ui.graphics.Color) {
+    androidx.compose.material3.Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 1.dp,
+        shadowElevation = 2.dp
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = accent
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/chirui/reader/catalog/CatalogDiscoverScreen.kt
+++ b/android/app/src/main/java/com/chirui/reader/catalog/CatalogDiscoverScreen.kt
@@ -1,0 +1,480 @@
+package com.chirui.reader.catalog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.FilterAlt
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chirui.domain.model.MangaStatus
+import kotlin.math.absoluteValue
+
+@Composable
+fun CatalogDiscoverTab(
+    onOpenManga: (String) -> Unit,
+    viewModel: CatalogGridViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        CatalogSearchBar(
+            value = uiState.query,
+            onValueChange = viewModel::onQueryChange,
+            placeholder = "Search manga across enabled sources",
+            onClear = viewModel::onClearFilters,
+            onRefresh = viewModel::onRefresh,
+        )
+
+        FilterSection(
+            uiState = uiState,
+            onToggleLanguage = viewModel::onToggleLanguage,
+            onToggleSource = viewModel::onToggleSource,
+            onToggleEnabled = viewModel::onToggleEnabledFilter,
+        )
+
+        when {
+            uiState.loading -> CatalogLoadingCard()
+            uiState.items.isEmpty() -> CatalogEmptyState()
+            else -> CatalogGrid(
+                items = uiState.items,
+                page = uiState.page,
+                totalPages = uiState.totalPages,
+                onPrevious = viewModel::onPreviousPage,
+                onNext = viewModel::onNextPage,
+                onOpenManga = onOpenManga,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CatalogSearchBar(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    onClear: () -> Unit,
+    onRefresh: () -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier.fillMaxWidth(),
+        placeholder = { Text(placeholder) },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        trailingIcon = {
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                TextButton(onClick = onClear) { Text("Reset") }
+                FilledIconButton(onClick = onRefresh) {
+                    Icon(imageVector = Icons.Default.Refresh, contentDescription = "Refresh catalog")
+                }
+            }
+        },
+        singleLine = true,
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            focusedBorderColor = MaterialTheme.colorScheme.primary,
+            unfocusedBorderColor = MaterialTheme.colorScheme.outline
+        )
+    )
+}
+
+@Composable
+private fun FilterSection(
+    uiState: CatalogUiState,
+    onToggleLanguage: (String) -> Unit,
+    onToggleSource: (String) -> Unit,
+    onToggleEnabled: (Boolean) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(
+                    imageVector = Icons.Default.FilterAlt,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "Filters",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+
+            if (uiState.languages.isNotEmpty()) {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        text = "Languages",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        uiState.languages.forEach { language ->
+                            val isSelected = uiState.selectedLanguages.contains(language)
+                            AssistChip(
+                                onClick = { onToggleLanguage(language) },
+                                label = { Text(language.uppercase()) },
+                                colors = AssistChipDefaults.assistChipColors(
+                                    containerColor = if (isSelected) {
+                                        MaterialTheme.colorScheme.primaryContainer
+                                    } else {
+                                        MaterialTheme.colorScheme.surface
+                                    }
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (uiState.sources.isNotEmpty()) {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        text = "Sources",
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    SourceFilterRow(
+                        sources = uiState.sources,
+                        selected = uiState.selectedSources,
+                        enabledOnly = uiState.onlyEnabledSources,
+                        onToggleSource = onToggleSource,
+                        onToggleEnabled = onToggleEnabled,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceFilterRow(
+    sources: List<SourceFilterUiModel>,
+    selected: Set<String>,
+    enabledOnly: Boolean,
+    onToggleSource: (String) -> Unit,
+    onToggleEnabled: (Boolean) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = "Enabled only",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Switch(
+                checked = enabledOnly,
+                onCheckedChange = onToggleEnabled,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                    checkedTrackColor = MaterialTheme.colorScheme.primary,
+                )
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            sources.forEach { source ->
+                val isSelected = selected.contains(source.id)
+                AssistChip(
+                    onClick = { onToggleSource(source.id) },
+                    label = { Text(source.name) },
+                    leadingIcon = {
+                        SourceLeadingIcon(language = source.language, enabled = source.enabled)
+                    },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = when {
+                            !source.enabled -> MaterialTheme.colorScheme.surfaceVariant
+                            isSelected -> MaterialTheme.colorScheme.primaryContainer
+                            else -> MaterialTheme.colorScheme.surface
+                        }
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceLeadingIcon(language: String, enabled: Boolean) {
+    val background = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outline
+    val contentColor = if (enabled) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+    Surface(
+        modifier = Modifier.size(20.dp),
+        color = background,
+        shape = RoundedCornerShape(6.dp),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = language.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = contentColor
+            )
+        }
+    }
+}
+
+@Composable
+private fun CatalogGrid(
+    items: List<CatalogItemUiModel>,
+    page: Int,
+    totalPages: Int,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    onOpenManga: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(minSize = 156.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            modifier = Modifier.fillMaxHeight(0.9f)
+        ) {
+            items(items, key = { it.id }) { item ->
+                CatalogCard(item = item, onOpenManga = onOpenManga)
+            }
+        }
+
+        PaginationBar(
+            page = page,
+            totalPages = totalPages,
+            onPrevious = onPrevious,
+            onNext = onNext
+        )
+    }
+}
+
+@Composable
+private fun CatalogCard(
+    item: CatalogItemUiModel,
+    onOpenManga: (String) -> Unit,
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onOpenManga(item.id) },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            CoverPlaceholder(id = item.id)
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                text = "${item.sourceName} · ${item.language.uppercase()}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                StatusBadge(status = item.status, nsfw = item.nsfw)
+            }
+            if (item.tags.isNotEmpty()) {
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    item.tags.take(3).forEach { tag ->
+                        AssistChip(
+                            onClick = {},
+                            label = { Text(tag) },
+                            colors = AssistChipDefaults.assistChipColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CoverPlaceholder(id: String) {
+    val colors = rememberCoverColors(id)
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(
+                Brush.verticalGradient(
+                    colors = colors
+                )
+            )
+            .fillMaxWidth()
+            .height(160.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = id.take(2).uppercase(),
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+    }
+}
+
+@Composable
+private fun rememberCoverColors(seed: String): List<Color> {
+    val hash = seed.hashCode().absoluteValue
+    val primary = Color(0xFF6C63FF).copy(alpha = 0.85f)
+    val alt = Color(0xFF00BCD4).copy(alpha = 0.85f)
+    val accent = Color(0xFFFF8A65).copy(alpha = 0.85f)
+    val palette = listOf(primary, alt, accent)
+    val first = palette[hash % palette.size]
+    val second = palette[(hash / 3) % palette.size]
+    return listOf(first, second)
+}
+
+@Composable
+private fun StatusBadge(status: MangaStatus, nsfw: Boolean) {
+    val (label, color) = when {
+        nsfw -> "NSFW" to MaterialTheme.colorScheme.error
+        status == MangaStatus.COMPLETED -> "Completed" to MaterialTheme.colorScheme.primary
+        status == MangaStatus.ONGOING -> "Ongoing" to MaterialTheme.colorScheme.tertiary
+        status == MangaStatus.HIATUS -> "Hiatus" to MaterialTheme.colorScheme.secondary
+        status == MangaStatus.CANCELLED -> "Cancelled" to MaterialTheme.colorScheme.outline
+        else -> "Unknown" to MaterialTheme.colorScheme.outline
+    }
+    Surface(
+        color = color.copy(alpha = 0.16f),
+        contentColor = color,
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun PaginationBar(
+    page: Int,
+    totalPages: Int,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            FilledIconButton(onClick = onPrevious, enabled = page > 0) {
+                Icon(imageVector = Icons.Default.ChevronLeft, contentDescription = "Previous page")
+            }
+            FilledIconButton(onClick = onNext, enabled = page < totalPages - 1) {
+                Icon(imageVector = Icons.Default.ChevronRight, contentDescription = "Next page")
+            }
+            Text(
+                text = "Page ${page + 1} of $totalPages",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+private fun CatalogLoadingCard() {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            CircularProgressIndicator(modifier = Modifier.size(28.dp))
+            Column {
+                Text(text = "Loading catalog…", style = MaterialTheme.typography.titleSmall)
+                Text(
+                    text = "Parsing Kotatsu fixtures from bundled assets.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CatalogEmptyState() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "No catalog results",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "Adjust filters or import more Kotatsu fixtures from your forks.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/chirui/reader/catalog/CatalogGridViewModel.kt
+++ b/android/app/src/main/java/com/chirui/reader/catalog/CatalogGridViewModel.kt
@@ -1,0 +1,202 @@
+package com.chirui.reader.catalog
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chirui.domain.catalog.CatalogRepository
+import com.chirui.domain.model.MangaStatus
+import com.chirui.domain.model.MangaSummary
+import com.chirui.parsers.ParserRegistry
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+private const val PAGE_SIZE = 6
+
+@HiltViewModel
+class CatalogGridViewModel @Inject constructor(
+    private val catalogRepository: CatalogRepository,
+    private val parserRegistry: ParserRegistry,
+) : ViewModel() {
+
+    private val query = MutableStateFlow("")
+    private val selectedLanguages = MutableStateFlow(emptySet<String>())
+    private val selectedSources = MutableStateFlow(emptySet<String>())
+    private val onlyEnabledSources = MutableStateFlow(true)
+    private val page = MutableStateFlow(0)
+
+    val uiState: StateFlow<CatalogUiState> = combine(
+        catalogRepository.catalogEntries(),
+        parserRegistry.availableSources(),
+        query,
+        selectedLanguages,
+        selectedSources,
+        page,
+        onlyEnabledSources,
+    ) { catalogEntries, sourceDescriptors, queryValue, languageSelection, sourceSelection, pageIndex, enforceEnabledSources ->
+        val enabledSourceIds = sourceDescriptors.filter { it.enabled }.map { it.id }.toSet()
+        val availableSourceIds = sourceDescriptors.map { it.id }.toSet()
+        val sourceFilter = if (sourceSelection.isEmpty()) {
+            if (enforceEnabledSources) enabledSourceIds else availableSourceIds
+        } else {
+            sourceSelection
+        }
+
+        val filtered = catalogEntries.filter { entry ->
+            val matchesQuery = queryValue.isBlank() ||
+                entry.title.contains(queryValue, ignoreCase = true) ||
+                entry.tags.any { it.contains(queryValue, ignoreCase = true) }
+            val matchesLanguage = languageSelection.isEmpty() || languageSelection.contains(entry.language)
+            val matchesSource = sourceFilter.isEmpty() || sourceFilter.contains(entry.sourceId)
+            val respectsEnabled = !enforceEnabledSources ||
+                enabledSourceIds.isEmpty() ||
+                enabledSourceIds.contains(entry.sourceId)
+            matchesQuery && matchesLanguage && matchesSource && respectsEnabled
+        }
+
+        val availableLanguages = catalogEntries.map { it.language }.distinct().sorted()
+        val totalPages = max(1, ceil(filtered.size / PAGE_SIZE.toDouble()).toInt())
+        val currentPage = pageIndex.coerceIn(0, totalPages - 1)
+        val pageItems = filtered
+            .drop(currentPage * PAGE_SIZE)
+            .take(PAGE_SIZE)
+            .map { entry ->
+                val sourceName = sourceDescriptors.firstOrNull { it.id == entry.sourceId }?.name
+                    ?: entry.sourceName
+                entry.toUiModel(sourceName)
+            }
+
+        CatalogUiState(
+            items = pageItems,
+            query = queryValue,
+            languages = availableLanguages,
+            selectedLanguages = languageSelection,
+            sources = sourceDescriptors.map { descriptor ->
+                SourceFilterUiModel(
+                    id = descriptor.id,
+                    name = descriptor.name,
+                    enabled = descriptor.enabled,
+                    language = descriptor.language,
+                )
+            },
+            selectedSources = sourceFilter,
+            page = currentPage,
+            totalPages = totalPages,
+            loading = false,
+            onlyEnabledSources = enforceEnabledSources,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = CatalogUiState(loading = true),
+    )
+
+    init {
+        viewModelScope.launch {
+            catalogRepository.reload()
+            parserRegistry.reload()
+        }
+    }
+
+    fun onQueryChange(value: String) {
+        query.value = value
+        page.value = 0
+    }
+
+    fun onToggleLanguage(language: String) {
+        selectedLanguages.update { current ->
+            if (current.contains(language)) current - language else current + language
+        }
+        page.value = 0
+    }
+
+    fun onToggleSource(sourceId: String) {
+        selectedSources.update { current ->
+            if (current.contains(sourceId)) current - sourceId else current + sourceId
+        }
+        page.value = 0
+    }
+
+    fun onToggleEnabledFilter(enabledOnly: Boolean) {
+        onlyEnabledSources.value = enabledOnly
+        if (enabledOnly) {
+            selectedSources.value = emptySet()
+        }
+        page.value = 0
+    }
+
+    fun onNextPage() {
+        val currentState = uiState.value
+        if (currentState.page < currentState.totalPages - 1) {
+            page.value = currentState.page + 1
+        }
+    }
+
+    fun onPreviousPage() {
+        val currentState = uiState.value
+        if (currentState.page > 0) {
+            page.value = currentState.page - 1
+        }
+    }
+
+    fun onRefresh() {
+        viewModelScope.launch { catalogRepository.reload() }
+    }
+
+    fun onClearFilters() {
+        selectedLanguages.value = emptySet()
+        selectedSources.value = emptySet()
+        query.value = ""
+        page.value = 0
+    }
+}
+
+private fun MangaSummary.toUiModel(sourceName: String?): CatalogItemUiModel = CatalogItemUiModel(
+    id = id,
+    title = title,
+    sourceName = sourceName ?: this.sourceName,
+    language = language,
+    coverUrl = coverUrl,
+    nsfw = nsfw,
+    status = status,
+    tags = tags,
+)
+
+data class CatalogUiState(
+    val items: List<CatalogItemUiModel> = emptyList(),
+    val query: String = "",
+    val languages: List<String> = emptyList(),
+    val selectedLanguages: Set<String> = emptySet(),
+    val sources: List<SourceFilterUiModel> = emptyList(),
+    val selectedSources: Set<String> = emptySet(),
+    val page: Int = 0,
+    val totalPages: Int = 1,
+    val loading: Boolean = false,
+    val onlyEnabledSources: Boolean = true,
+    val error: String? = null,
+)
+
+data class CatalogItemUiModel(
+    val id: String,
+    val title: String,
+    val sourceName: String,
+    val language: String,
+    val coverUrl: String?,
+    val nsfw: Boolean,
+    val status: MangaStatus,
+    val tags: List<String>,
+)
+
+data class SourceFilterUiModel(
+    val id: String,
+    val name: String,
+    val enabled: Boolean,
+    val language: String,
+)

--- a/android/app/src/main/java/com/chirui/reader/catalog/CatalogScreen.kt
+++ b/android/app/src/main/java/com/chirui/reader/catalog/CatalogScreen.kt
@@ -1,0 +1,40 @@
+package com.chirui.reader.catalog
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+private enum class CatalogTab(val label: String) {
+    Discover("Discover"),
+    Sources("Sources"),
+}
+
+@Composable
+fun CatalogScreen(onOpenManga: (String) -> Unit) {
+    var selectedTab by rememberSaveable { mutableStateOf(CatalogTab.Discover) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TabRow(selectedTabIndex = selectedTab.ordinal) {
+            CatalogTab.values().forEach { tab ->
+                Tab(
+                    selected = tab == selectedTab,
+                    onClick = { selectedTab = tab },
+                    text = { Text(tab.label) },
+                )
+            }
+        }
+
+        when (selectedTab) {
+            CatalogTab.Discover -> CatalogDiscoverTab(onOpenManga = onOpenManga)
+            CatalogTab.Sources -> SourceListTab()
+        }
+    }
+}

--- a/android/app/src/main/java/com/chirui/reader/catalog/MangaDetailScreen.kt
+++ b/android/app/src/main/java/com/chirui/reader/catalog/MangaDetailScreen.kt
@@ -1,0 +1,320 @@
+package com.chirui.reader.catalog
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chirui.domain.model.ChapterSummary
+import com.chirui.domain.model.MangaDetail
+import com.chirui.domain.model.MangaStatus
+import kotlin.math.absoluteValue
+
+@Composable
+fun MangaDetailScreen(
+    onShare: (MangaDetail) -> Unit,
+    onOpenChapter: (ChapterSummary) -> Unit,
+    viewModel: MangaDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when {
+        state.loading -> LoadingState()
+        state.error != null -> ErrorState(message = state.error ?: "", onRetry = viewModel::refresh)
+        state.detail != null -> MangaDetailContent(
+            detail = state.detail,
+            onToggleFavorite = viewModel::onToggleFavorite,
+            onShare = onShare,
+            onOpenChapter = onOpenChapter,
+        )
+    }
+}
+
+@Composable
+private fun MangaDetailContent(
+    detail: MangaDetail,
+    onToggleFavorite: () -> Unit,
+    onShare: (MangaDetail) -> Unit,
+    onOpenChapter: (ChapterSummary) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            CoverPreview(id = detail.summary.id, modifier = Modifier.weight(1f))
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = detail.summary.title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = "${detail.summary.sourceName} · ${detail.summary.language.uppercase()}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    StatusBadge(status = detail.status, nsfw = detail.summary.nsfw)
+                    AssistChip(
+                        onClick = onToggleFavorite,
+                        leadingIcon = {
+                            Icon(
+                                imageVector = if (detail.favorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                contentDescription = null,
+                                tint = if (detail.favorite) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        label = { Text(if (detail.favorite) "Favorited" else "Add to library") },
+                    )
+                }
+                if (detail.tags.isNotEmpty()) {
+                    FlowingTags(tags = detail.tags)
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = { onShare(detail) }) {
+                        Icon(Icons.Default.Share, contentDescription = null)
+                        Text(text = "Share", modifier = Modifier.padding(start = 6.dp))
+                    }
+                    Button(
+                        onClick = { /* download pipeline placeholder */ },
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
+                    ) {
+                        Icon(Icons.Default.CloudDownload, contentDescription = null)
+                        Text(text = "Download", modifier = Modifier.padding(start = 6.dp))
+                    }
+                }
+            }
+        }
+
+        if (!detail.description.isNullOrBlank()) {
+            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+                Text(
+                    text = detail.description,
+                    modifier = Modifier.padding(12.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+
+        MetadataSection(detail = detail)
+
+        ChapterSection(chapters = detail.chapters, onOpenChapter = onOpenChapter)
+    }
+}
+
+@Composable
+private fun MetadataSection(detail: MangaDetail) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(text = "Metadata", style = MaterialTheme.typography.titleMedium)
+            detail.author?.let {
+                Text(
+                    text = "Author: $it",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            detail.artist?.let {
+                Text(
+                    text = "Artist: $it",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            detail.sourceUrl?.let {
+                Text(
+                    text = "Source link: $it",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChapterSection(chapters: List<ChapterSummary>, onOpenChapter: (ChapterSummary) -> Unit) {
+    Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text = "Chapters", style = MaterialTheme.typography.titleMedium)
+            if (chapters.isEmpty()) {
+                Text(
+                    text = "No chapters yet — add parser outputs or sync assets.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                chapters.forEach { chapter ->
+                    ChapterRow(chapter = chapter, onOpenChapter = onOpenChapter)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChapterRow(chapter: ChapterSummary, onOpenChapter: (ChapterSummary) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = chapter.title,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            val chapterLabel = chapter.number?.let { number ->
+                "Chapter ${number.toInt()}"
+            } ?: "Chapter"
+            Text(
+                text = chapterLabel,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            AssistChip(onClick = { onOpenChapter(chapter) }, label = { Text(text = "Read") })
+            AssistChip(
+                onClick = { /* download hook */ },
+                leadingIcon = { Icon(Icons.Default.CloudDownload, contentDescription = null) },
+                label = { Text(text = "Download") },
+            )
+            if (chapter.readProgress >= 1f) {
+                Icon(imageVector = Icons.Default.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.secondary)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FlowingTags(tags: List<String>) {
+    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        tags.take(4).forEach { tag ->
+            AssistChip(onClick = {}, label = { Text(tag) })
+        }
+    }
+}
+
+@Composable
+private fun CoverPreview(id: String, modifier: Modifier = Modifier) {
+    val colors = rememberCoverColors(id)
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+            .background(Brush.verticalGradient(colors))
+            .height(200.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = id.take(3).uppercase(),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onPrimary
+        )
+    }
+}
+
+@Composable
+private fun LoadingState() {
+    Box(modifier = Modifier.fillMaxWidth().padding(24.dp), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ErrorState(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = message, style = MaterialTheme.typography.bodyLarge)
+        Button(onClick = onRetry) {
+            Icon(Icons.Default.Refresh, contentDescription = null)
+            Text(text = "Retry", modifier = Modifier.padding(start = 6.dp))
+        }
+    }
+}
+
+@Composable
+private fun rememberCoverColors(seed: String): List<Color> {
+    val hash = seed.hashCode().absoluteValue
+    val primary = Color(0xFF5E81F4).copy(alpha = 0.9f)
+    val alt = Color(0xFF4DD0E1).copy(alpha = 0.9f)
+    val accent = Color(0xFFFFB74D).copy(alpha = 0.9f)
+    val palette = listOf(primary, alt, accent)
+    val first = palette[hash % palette.size]
+    val second = palette[(hash / 3) % palette.size]
+    return listOf(first, second)
+}
+
+@Composable
+private fun StatusBadge(status: MangaStatus, nsfw: Boolean) {
+    val (label, color) = when {
+        nsfw -> "NSFW" to MaterialTheme.colorScheme.error
+        status == MangaStatus.COMPLETED -> "Completed" to MaterialTheme.colorScheme.primary
+        status == MangaStatus.ONGOING -> "Ongoing" to MaterialTheme.colorScheme.tertiary
+        status == MangaStatus.HIATUS -> "Hiatus" to MaterialTheme.colorScheme.secondary
+        status == MangaStatus.CANCELLED -> "Cancelled" to MaterialTheme.colorScheme.outline
+        else -> "Unknown" to MaterialTheme.colorScheme.outline
+    }
+    Surface(
+        color = color.copy(alpha = 0.16f),
+        contentColor = color,
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/android/app/src/main/java/com/chirui/reader/catalog/MangaDetailViewModel.kt
+++ b/android/app/src/main/java/com/chirui/reader/catalog/MangaDetailViewModel.kt
@@ -1,0 +1,65 @@
+package com.chirui.reader.catalog
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chirui.domain.catalog.CatalogRepository
+import com.chirui.domain.model.MangaDetail
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class MangaDetailViewModel @Inject constructor(
+    private val catalogRepository: CatalogRepository,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val mangaId: String = savedStateHandle.get<String>("mangaId").orEmpty()
+
+    private val _uiState = MutableStateFlow(MangaDetailUiState(loading = true))
+    val uiState: StateFlow<MangaDetailUiState> = _uiState
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(loading = true, error = null) }
+            runCatching { catalogRepository.mangaDetail(mangaId) }
+                .onSuccess { detail ->
+                    _uiState.value = MangaDetailUiState(
+                        loading = false,
+                        detail = detail,
+                        error = if (detail == null) "Manga not found" else null,
+                    )
+                }
+                .onFailure { throwable ->
+                    _uiState.value = MangaDetailUiState(
+                        loading = false,
+                        detail = null,
+                        error = throwable.message ?: "Failed to load detail",
+                    )
+                }
+        }
+    }
+
+    fun onToggleFavorite() {
+        val currentDetail = _uiState.value.detail ?: return
+        val nextFavorite = !currentDetail.favorite
+        _uiState.update { state ->
+            state.copy(detail = currentDetail.copy(favorite = nextFavorite))
+        }
+        viewModelScope.launch { catalogRepository.setFavorite(currentDetail.summary.id, nextFavorite) }
+    }
+}
+
+data class MangaDetailUiState(
+    val loading: Boolean = false,
+    val detail: MangaDetail? = null,
+    val error: String? = null,
+)

--- a/android/app/src/main/java/com/chirui/reader/catalog/SourceListScreen.kt
+++ b/android/app/src/main/java/com/chirui/reader/catalog/SourceListScreen.kt
@@ -1,0 +1,308 @@
+package com.chirui.reader.catalog
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.FilterAlt
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@Composable
+fun SourceListTab(viewModel: SourceListViewModel = hiltViewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        SearchBar(
+            value = uiState.query,
+            onValueChange = viewModel::onQueryChange,
+            placeholder = "Search sources"
+        )
+
+        if (uiState.languages.isNotEmpty()) {
+            LanguageFilters(
+                languages = uiState.languages,
+                selected = uiState.selectedLanguages,
+                onToggle = viewModel::onToggleLanguage
+            )
+        }
+
+        when {
+            uiState.loading -> LoadingCard()
+            uiState.error != null -> ErrorCard(uiState.error, onRetry = viewModel::onRetry)
+            uiState.sources.isEmpty() -> EmptyState()
+            else -> SourceList(
+                sources = uiState.sources,
+                onToggle = viewModel::onToggleEnabled
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchBar(value: String, onValueChange: (String) -> Unit, placeholder: String) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = Modifier.fillMaxWidth(),
+        placeholder = { Text(placeholder) },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        singleLine = true,
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            focusedBorderColor = MaterialTheme.colorScheme.primary,
+            unfocusedBorderColor = MaterialTheme.colorScheme.outline
+        )
+    )
+}
+
+@Composable
+private fun LanguageFilters(
+    languages: List<String>,
+    selected: Set<String>,
+    onToggle: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Default.FilterAlt,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = "Languages",
+                modifier = Modifier.padding(start = 8.dp),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            languages.forEach { language ->
+                val isSelected = selected.contains(language)
+                AssistChip(
+                    onClick = { onToggle(language) },
+                    label = { Text(language.uppercase()) },
+                    leadingIcon = if (isSelected) {
+                        {
+                            Icon(
+                                imageVector = Icons.Default.FilterAlt,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                        }
+                    } else null,
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = if (isSelected) {
+                            MaterialTheme.colorScheme.primaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.surfaceVariant
+                        }
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SourceList(sources: List<SourceUiModel>, onToggle: (String, Boolean) -> Unit) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(sources, key = { it.id }) { source ->
+            SourceCard(source = source, onToggle = onToggle)
+        }
+        item { Spacer(modifier = Modifier.height(32.dp)) }
+    }
+}
+
+@Composable
+private fun SourceCard(source: SourceUiModel, onToggle: (String, Boolean) -> Unit) {
+    OutlinedCard(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = source.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = source.language.uppercase(),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+                Switch(
+                    checked = source.enabled,
+                    onCheckedChange = { onToggle(source.id, it) },
+                    colors = SwitchDefaults.colors(
+                        checkedTrackColor = MaterialTheme.colorScheme.primary,
+                        checkedThumbColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                )
+            }
+
+            if (source.description != null) {
+                Text(
+                    text = source.description,
+                    modifier = Modifier.padding(top = 8.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            if (source.nsfw) {
+                Text(
+                    text = "NSFW",
+                    modifier = Modifier.padding(top = 8.dp),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.error,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingCard() {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            CircularProgressIndicator(modifier = Modifier.size(28.dp))
+            Column {
+                Text(text = "Loading sources…", style = MaterialTheme.typography.titleSmall)
+                Text(
+                    text = "Parsing Kotatsu registry from bundled assets.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorCard(message: String, onRetry: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer)
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.ErrorOutline,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Couldn't load sources",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer
+                )
+            }
+            TextButton(onClick = onRetry) {
+                Text("Retry")
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyState() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "No sources yet",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Text(
+                text = "Import Kotatsu parser assets to see the full registry here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/chirui/reader/catalog/SourceListViewModel.kt
+++ b/android/app/src/main/java/com/chirui/reader/catalog/SourceListViewModel.kt
@@ -1,0 +1,102 @@
+package com.chirui.reader.catalog
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chirui.domain.model.SourceDescriptor
+import com.chirui.parsers.ParserRegistry
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SourceListViewModel @Inject constructor(
+    private val parserRegistry: ParserRegistry,
+) : ViewModel() {
+
+    private val query = MutableStateFlow("")
+    private val selectedLanguages = MutableStateFlow(emptySet<String>())
+
+    val uiState: StateFlow<SourceListUiState> = combine(
+        parserRegistry.availableSources(),
+        query,
+        selectedLanguages,
+    ) { sources, queryValue, languageSelection ->
+        val filtered = sources.filter { descriptor ->
+            val matchesQuery = queryValue.isBlank() ||
+                descriptor.name.contains(queryValue, ignoreCase = true) ||
+                (descriptor.description?.contains(queryValue, ignoreCase = true) ?: false)
+            val matchesLanguage = languageSelection.isEmpty() || languageSelection.contains(descriptor.language)
+            matchesQuery && matchesLanguage
+        }
+        val availableLanguages = sources.map { it.language }.distinct().sorted()
+
+        SourceListUiState(
+            sources = filtered.map { descriptor -> descriptor.toUiModel() },
+            languages = availableLanguages,
+            query = queryValue,
+            selectedLanguages = languageSelection,
+            loading = false,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = SourceListUiState(loading = true),
+    )
+
+    init {
+        viewModelScope.launch { parserRegistry.reload() }
+    }
+
+    fun onQueryChange(value: String) {
+        query.value = value
+    }
+
+    fun onToggleLanguage(language: String) {
+        val current = selectedLanguages.value
+        selectedLanguages.value = if (current.contains(language)) {
+            current - language
+        } else {
+            current + language
+        }
+    }
+
+    fun onToggleEnabled(sourceId: String, enabled: Boolean) {
+        viewModelScope.launch { parserRegistry.setEnabled(sourceId, enabled) }
+    }
+
+    fun onRetry() {
+        viewModelScope.launch { parserRegistry.reload() }
+    }
+}
+
+private fun SourceDescriptor.toUiModel(): SourceUiModel = SourceUiModel(
+    id = id,
+    name = name,
+    language = language,
+    description = description,
+    nsfw = nsfw,
+    enabled = enabled,
+)
+
+data class SourceListUiState(
+    val sources: List<SourceUiModel> = emptyList(),
+    val languages: List<String> = emptyList(),
+    val query: String = "",
+    val selectedLanguages: Set<String> = emptySet(),
+    val loading: Boolean = false,
+    val error: String? = null,
+)
+
+data class SourceUiModel(
+    val id: String,
+    val name: String,
+    val language: String,
+    val description: String?,
+    val nsfw: Boolean,
+    val enabled: Boolean,
+)

--- a/android/app/src/main/java/com/chirui/reader/downloads/DownloadsScreen.kt
+++ b/android/app/src/main/java/com/chirui/reader/downloads/DownloadsScreen.kt
@@ -1,0 +1,238 @@
+package com.chirui.reader.downloads
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.chirui.domain.model.DownloadItem
+import com.chirui.domain.model.DownloadStatus
+
+@Composable
+fun DownloadsScreen(viewModel: DownloadsViewModel = hiltViewModel()) {
+    val state by viewModel.state.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        DownloadSummaryRow(
+            active = state.activeCount,
+            completed = state.completedCount,
+            queued = state.queue.count { it.status == DownloadStatus.QUEUED }
+        )
+
+        if (state.queue.isEmpty()) {
+            EmptyDownloads()
+        } else {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                items(state.queue) { item ->
+                    DownloadCard(
+                        item = item,
+                        onPause = { viewModel.pause(item.id) },
+                        onResume = { viewModel.resume(item.id) },
+                        onCancel = { viewModel.cancel(item.id) },
+                        onRetry = { viewModel.retry(item.id) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadSummaryRow(active: Int, completed: Int, queued: Int) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        SummaryChip(text = "$active active")
+        SummaryChip(text = "$queued queued")
+        SummaryChip(text = "$completed done")
+    }
+}
+
+@Composable
+private fun SummaryChip(text: String) {
+    AssistChip(onClick = {}, label = { Text(text) })
+}
+
+@Composable
+private fun DownloadCard(
+    item: DownloadItem,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onCancel: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Icon(
+                    imageVector = when (item.status) {
+                        DownloadStatus.DOWNLOADING -> Icons.Default.Download
+                        DownloadStatus.COMPLETED -> Icons.Default.CheckCircle
+                        DownloadStatus.PAUSED -> Icons.Default.Pause
+                        DownloadStatus.FAILED -> Icons.Default.Refresh
+                        DownloadStatus.CANCELED -> Icons.Default.Cancel
+                        DownloadStatus.QUEUED -> Icons.Default.Download
+                    },
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = item.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = item.source,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            LinearProgressIndicator(
+                progress = { item.progress.coerceIn(0f, 1f) },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = item.statusLabel(),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                    if (item.etaMinutes != null || item.sizeLabel != null) {
+                        Text(
+                            text = listOfNotNull(
+                                item.sizeLabel,
+                                item.etaMinutes?.let { "ETA ${it}m" }
+                            ).joinToString(" · "),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    when (item.status) {
+                        DownloadStatus.DOWNLOADING -> {
+                            IconButton(onClick = onPause) { Icon(Icons.Default.Pause, contentDescription = "Pause") }
+                            IconButton(onClick = onCancel) { Icon(Icons.Default.Cancel, contentDescription = "Cancel") }
+                        }
+                        DownloadStatus.PAUSED, DownloadStatus.QUEUED -> {
+                            IconButton(onClick = onResume) { Icon(Icons.Default.PlayArrow, contentDescription = "Resume") }
+                            IconButton(onClick = onCancel) { Icon(Icons.Default.Cancel, contentDescription = "Cancel") }
+                        }
+                        DownloadStatus.FAILED, DownloadStatus.CANCELED -> {
+                            IconButton(onClick = onRetry) { Icon(Icons.Default.Refresh, contentDescription = "Retry") }
+                        }
+                        DownloadStatus.COMPLETED -> {
+                            IconButton(onClick = onCancel) { Icon(Icons.Default.Cancel, contentDescription = "Remove") }
+                        }
+                    }
+                }
+            }
+
+            if (item.chapters.isNotEmpty()) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+                ) {
+                    Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        item.chapters.forEach { chapter ->
+                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                Text(
+                                    text = chapter.name,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                LinearProgressIndicator(
+                                    progress = { chapter.progress.coerceIn(0f, 1f) },
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyDownloads() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text("No downloads yet", style = MaterialTheme.typography.titleMedium)
+            Text(
+                "New downloads from catalog detail and reader actions will appear here.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+        }
+    }
+}
+
+private fun DownloadItem.statusLabel(): String = when (status) {
+    DownloadStatus.DOWNLOADING -> "Downloading ${(progress * 100).toInt()}%"
+    DownloadStatus.QUEUED -> "Queued"
+    DownloadStatus.PAUSED -> "Paused"
+    DownloadStatus.COMPLETED -> "Completed"
+    DownloadStatus.FAILED -> "Failed"
+    DownloadStatus.CANCELED -> "Canceled"
+}

--- a/android/app/src/main/java/com/chirui/reader/downloads/DownloadsViewModel.kt
+++ b/android/app/src/main/java/com/chirui/reader/downloads/DownloadsViewModel.kt
@@ -1,0 +1,56 @@
+package com.chirui.reader.downloads
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chirui.domain.downloads.DownloadRepository
+import com.chirui.domain.model.DownloadItem
+import com.chirui.domain.model.DownloadStatus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class DownloadsViewModel @Inject constructor(
+    private val downloads: DownloadRepository,
+) : ViewModel() {
+
+    val state: StateFlow<DownloadUiState> = downloads.observeQueue()
+        .map { queue ->
+            DownloadUiState(
+                queue = queue,
+                activeCount = queue.count { it.status == DownloadStatus.DOWNLOADING },
+                completedCount = queue.count { it.status == DownloadStatus.COMPLETED },
+            )
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = DownloadUiState(),
+        )
+
+    fun pause(id: String) {
+        viewModelScope.launch { downloads.pause(id) }
+    }
+
+    fun resume(id: String) {
+        viewModelScope.launch { downloads.resume(id) }
+    }
+
+    fun cancel(id: String) {
+        viewModelScope.launch { downloads.cancel(id) }
+    }
+
+    fun retry(id: String) {
+        viewModelScope.launch { downloads.retry(id) }
+    }
+}
+
+data class DownloadUiState(
+    val queue: List<DownloadItem> = emptyList(),
+    val activeCount: Int = 0,
+    val completedCount: Int = 0,
+)

--- a/android/app/src/main/java/com/chirui/reader/reader/ReaderScreen.kt
+++ b/android/app/src/main/java/com/chirui/reader/reader/ReaderScreen.kt
@@ -1,0 +1,201 @@
+package com.chirui.reader.reader
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.clickable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ReaderScreen(
+    onBack: () -> Unit,
+    onShare: () -> Unit,
+    onDownload: () -> Unit,
+    viewModel: ReaderViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when {
+        state.loading -> ReaderLoading()
+        state.error != null -> ReaderError(message = state.error ?: "", onRetry = viewModel::refresh)
+        state.chapter != null -> ReaderContent(
+            state = state,
+            onBack = onBack,
+            onShare = onShare,
+            onDownload = onDownload,
+            onPageChanged = viewModel::onPageChanged,
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ReaderContent(
+    state: ReaderUiState,
+    onBack: () -> Unit,
+    onShare: () -> Unit,
+    onDownload: () -> Unit,
+    onPageChanged: (Int) -> Unit,
+) {
+    val chapter = state.chapter ?: return
+    val pagerState = rememberPagerState(initialPage = state.currentPage, pageCount = { chapter.pages.size })
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(pagerState.currentPage) {
+        onPageChanged(pagerState.currentPage)
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = chapter.chapterTitle,
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = chapter.mangaTitle,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onShare) {
+                        Icon(Icons.Default.Share, contentDescription = "Share")
+                    }
+                    IconButton(onClick = onDownload) {
+                        Icon(Icons.Default.CloudDownload, contentDescription = "Download")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            HorizontalPager(state = pagerState, modifier = Modifier.weight(1f)) { page ->
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    AsyncImage(
+                        model = chapter.pages[page].imageUrl,
+                        contentDescription = "Page ${page + 1}",
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+
+            ReaderFooter(
+                current = pagerState.currentPage,
+                total = chapter.pages.size,
+                onSeek = { page ->
+                    scope.launch {
+                        pagerState.animateScrollToPage(page)
+                        onPageChanged(page)
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReaderFooter(current: Int, total: Int, onSeek: (Int) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(text = "Page ${current + 1} of $total", style = MaterialTheme.typography.bodyMedium)
+            Text(text = "Swipe or use slider", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Slider(
+            value = current.toFloat(),
+            onValueChange = { value -> onSeek(value.toInt().coerceIn(0, total - 1)) },
+            valueRange = 0f..(total - 1).toFloat(),
+            steps = (total - 2).coerceAtLeast(0),
+            colors = SliderDefaults.colors(
+                thumbColor = MaterialTheme.colorScheme.primary,
+                activeTrackColor = MaterialTheme.colorScheme.primary,
+            )
+        )
+    }
+}
+
+@Composable
+private fun ReaderLoading() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun ReaderError(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(Icons.Default.Refresh, contentDescription = null)
+        Text(text = message, style = MaterialTheme.typography.bodyLarge)
+        Text(
+            text = "Tap to retry", style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier
+                .clickable { onRetry() }
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .padding(horizontal = 12.dp, vertical = 6.dp)
+        )
+    }
+}

--- a/android/app/src/main/java/com/chirui/reader/reader/ReaderViewModel.kt
+++ b/android/app/src/main/java/com/chirui/reader/reader/ReaderViewModel.kt
@@ -1,0 +1,64 @@
+package com.chirui.reader.reader
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chirui.domain.reader.ReaderRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ReaderViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val readerRepository: ReaderRepository,
+) : ViewModel() {
+
+    private val chapterId: String = savedStateHandle.get<String>("chapterId").orEmpty()
+
+    private val _uiState = MutableStateFlow(ReaderUiState(loading = true))
+    val uiState: StateFlow<ReaderUiState> = _uiState
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(loading = true, error = null) }
+            runCatching { readerRepository.loadChapter(chapterId) }
+                .onSuccess { chapter ->
+                    _uiState.value = ReaderUiState(
+                        loading = false,
+                        chapterId = chapterId,
+                        chapter = chapter,
+                        error = if (chapter == null) "Chapter not found" else null,
+                        currentPage = 0,
+                    )
+                }
+                .onFailure { throwable ->
+                    _uiState.value = ReaderUiState(
+                        loading = false,
+                        chapterId = chapterId,
+                        chapter = null,
+                        error = throwable.message ?: "Failed to load chapter",
+                    )
+                }
+        }
+    }
+
+    fun onPageChanged(page: Int) {
+        _uiState.update { state -> state.copy(currentPage = page.coerceAtLeast(0)) }
+    }
+}
+
+data class ReaderUiState(
+    val loading: Boolean = false,
+    val chapterId: String? = null,
+    val chapter: com.chirui.domain.model.ReaderChapter? = null,
+    val error: String? = null,
+    val currentPage: Int = 0,
+)

--- a/android/app/src/main/java/com/chirui/reader/ui/theme/Colors.kt
+++ b/android/app/src/main/java/com/chirui/reader/ui/theme/Colors.kt
@@ -1,0 +1,62 @@
+package com.chirui.reader.ui.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+
+// Kotatsu-inspired palette tuned for dark first with warm orange accents
+val Flame = Color(0xFFFF7849)
+val FlameStrong = Color(0xFFFF6A30)
+val Ink = Color(0xFF0F172A)
+val InkMuted = Color(0xFF1E293B)
+val Paper = Color(0xFFF8FAFC)
+val PaperMuted = Color(0xFFE2E8F0)
+val Jade = Color(0xFF35C8A5)
+val Sky = Color(0xFF60A5FA)
+val Warning = Color(0xFFFFB74D)
+val Danger = Color(0xFFEF5350)
+
+val LightColorScheme = androidx.compose.material3.lightColorScheme(
+    primary = FlameStrong,
+    onPrimary = Color.White,
+    primaryContainer = Flame.copy(alpha = 0.14f).compositeOver(Paper),
+    onPrimaryContainer = FlameStrong,
+    secondary = Jade,
+    onSecondary = Color(0xFF052016),
+    secondaryContainer = Jade.copy(alpha = 0.16f).compositeOver(Paper),
+    onSecondaryContainer = Jade,
+    tertiary = Sky,
+    onTertiary = Color(0xFF0B2544),
+    background = Paper,
+    onBackground = Ink,
+    surface = Color.White,
+    onSurface = Ink,
+    surfaceVariant = PaperMuted,
+    onSurfaceVariant = InkMuted,
+    outline = InkMuted.copy(alpha = 0.4f),
+    outlineVariant = InkMuted.copy(alpha = 0.25f),
+    error = Danger,
+    onError = Color.White
+)
+
+val DarkColorScheme = androidx.compose.material3.darkColorScheme(
+    primary = Flame,
+    onPrimary = Color.White,
+    primaryContainer = Flame.copy(alpha = 0.2f).compositeOver(Ink),
+    onPrimaryContainer = Color.White,
+    secondary = Jade,
+    onSecondary = Color(0xFF08241A),
+    secondaryContainer = Jade.copy(alpha = 0.2f).compositeOver(Ink),
+    onSecondaryContainer = Color.White,
+    tertiary = Sky,
+    onTertiary = Color(0xFF0A1C2F),
+    background = Ink,
+    onBackground = Paper,
+    surface = InkMuted,
+    onSurface = Paper,
+    surfaceVariant = InkMuted.copy(alpha = 0.8f),
+    onSurfaceVariant = PaperMuted,
+    outline = PaperMuted.copy(alpha = 0.3f),
+    outlineVariant = PaperMuted.copy(alpha = 0.2f),
+    error = Danger,
+    onError = Color.White
+)

--- a/android/app/src/main/java/com/chirui/reader/ui/theme/Shapes.kt
+++ b/android/app/src/main/java/com/chirui/reader/ui/theme/Shapes.kt
@@ -1,0 +1,12 @@
+package com.chirui.reader.ui.theme
+
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+val AppShapes = Shapes(
+    extraSmall = androidx.compose.foundation.shape.RoundedCornerShape(6.dp),
+    small = androidx.compose.foundation.shape.RoundedCornerShape(10.dp),
+    medium = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
+    large = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
+    extraLarge = androidx.compose.foundation.shape.RoundedCornerShape(28.dp)
+)

--- a/android/app/src/main/java/com/chirui/reader/ui/theme/Theme.kt
+++ b/android/app/src/main/java/com/chirui/reader/ui/theme/Theme.kt
@@ -1,0 +1,19 @@
+package com.chirui.reader.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+
+@Composable
+fun ChiruiReaderTheme(
+    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (useDarkTheme) DarkColorScheme else LightColorScheme
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = AppTypography,
+        shapes = AppShapes,
+        content = content
+    )
+}

--- a/android/app/src/main/java/com/chirui/reader/ui/theme/Typography.kt
+++ b/android/app/src/main/java/com/chirui/reader/ui/theme/Typography.kt
@@ -1,0 +1,58 @@
+package com.chirui.reader.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val AppTypography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 48.sp,
+        letterSpacing = 0.1.sp
+    ),
+    headlineMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 26.sp,
+        letterSpacing = 0.sp
+    ),
+    headlineSmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 22.sp,
+        letterSpacing = 0.sp
+    ),
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 18.sp,
+        letterSpacing = 0.1.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        letterSpacing = 0.1.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        letterSpacing = 0.2.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        letterSpacing = 0.3.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
+        letterSpacing = 0.3.sp
+    )
+)

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,12 @@
+<resources>
+    <color name="color_flame">#FF7849</color>
+    <color name="color_flame_strong">#FF6A30</color>
+    <color name="color_ink">#0F172A</color>
+    <color name="color_ink_muted">#1E293B</color>
+    <color name="color_paper">#F8FAFC</color>
+    <color name="color_paper_muted">#E2E8F0</color>
+    <color name="color_jade">#35C8A5</color>
+    <color name="color_sky">#60A5FA</color>
+    <color name="color_warning">#FFB74D</color>
+    <color name="color_danger">#EF5350</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Chirui Reader</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.ChiruiReader" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
+        <item name="android:windowSplashScreenBackground">@android:color/white</item>
+        <item name="android:fontFamily">sans-serif</item>
+    </style>
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,9 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id("com.android.application") version "8.5.0" apply false
+    id("com.android.library") version "8.5.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("org.jetbrains.kotlin.jvm") version "1.9.24" apply false
+    id("com.google.dagger.hilt.android") version "2.51.1" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.24" apply false
+}

--- a/android/data/build.gradle.kts
+++ b/android/data/build.gradle.kts
@@ -1,0 +1,54 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.kapt")
+    id("com.google.dagger.hilt.android")
+    id("org.jetbrains.kotlin.plugin.serialization")
+}
+
+android {
+    namespace = "com.chirui.data"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 34
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":domain"))
+    implementation(project(":parsers"))
+
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.11.0")
+    implementation("com.squareup.moshi:moshi-kotlin:1.15.1")
+
+    implementation("com.google.dagger:hilt-android:2.51.1")
+    kapt("com.google.dagger:hilt-compiler:2.51.1")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+}
+
+kapt {
+    correctErrorTypes = true
+}

--- a/android/data/src/main/java/com/chirui/data/catalog/AssetCatalogRepository.kt
+++ b/android/data/src/main/java/com/chirui/data/catalog/AssetCatalogRepository.kt
@@ -1,0 +1,201 @@
+package com.chirui.data.catalog
+
+import android.content.Context
+import android.util.Log
+import com.chirui.domain.DispatcherProvider
+import com.chirui.domain.catalog.CatalogRepository
+import com.chirui.domain.model.ChapterSummary
+import com.chirui.domain.model.MangaDetail
+import com.chirui.domain.model.MangaStatus
+import com.chirui.domain.model.MangaSummary
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Singleton
+class AssetCatalogRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatchers: DispatcherProvider,
+) : CatalogRepository {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val scope = CoroutineScope(dispatchers.io + SupervisorJob())
+    private val catalog = MutableStateFlow<List<MangaSummary>>(emptyList())
+    private val favorites = MutableStateFlow<Set<String>>(emptySet())
+    private val details = MutableStateFlow<Map<String, MangaDetail>>(emptyMap())
+
+    init {
+        scope.launch { reload() }
+    }
+
+    override fun catalogEntries(): Flow<List<MangaSummary>> = catalog.asStateFlow()
+
+    override suspend fun reload() {
+        val entries = runCatching { readCatalog() }.getOrElse { throwable ->
+            Log.e("AssetCatalogRepository", "Failed to load catalog fixtures", throwable)
+            emptyList()
+        }
+        val detailMap = runCatching { readDetails() }.getOrElse { throwable ->
+            Log.e("AssetCatalogRepository", "Failed to load catalog details", throwable)
+            emptyMap()
+        }
+        catalog.value = entries
+        details.value = detailMap
+    }
+
+    override suspend fun mangaDetail(id: String): MangaDetail? = withContext(dispatchers.io) {
+        val favoriteSet = favorites.value
+        val stored = details.value[id]
+        stored?.copy(favorite = favoriteSet.contains(id)) ?: run {
+            // fallback to summary-only mapping
+            val summary = catalog.value.firstOrNull { it.id == id }
+            summary?.let {
+                MangaDetail(
+                    summary = it,
+                    status = it.status,
+                    tags = it.tags,
+                    description = it.description,
+                    favorite = favoriteSet.contains(id)
+                )
+            }
+        }
+    }
+
+    override suspend fun setFavorite(id: String, favorite: Boolean) {
+        favorites.value = if (favorite) favorites.value + id else favorites.value - id
+    }
+
+    private suspend fun readCatalog(): List<MangaSummary> = withContext(dispatchers.io) {
+        val assetManager = context.assets
+        val fileContent = assetManager
+            .open("catalog/featured.json")
+            .bufferedReader()
+            .use { it.readText() }
+
+        val records = json.decodeFromString<List<CatalogRecord>>(fileContent)
+        records.map { record ->
+            MangaSummary(
+                id = record.id,
+                title = record.title,
+                sourceId = record.sourceId,
+                sourceName = record.sourceName,
+                language = record.language,
+                coverUrl = record.coverUrl,
+                nsfw = record.nsfw ?: false,
+                status = record.status?.toStatusEnum() ?: MangaStatus.UNKNOWN,
+                tags = record.tags ?: emptyList(),
+                description = record.description,
+            )
+        }
+    }
+
+    private suspend fun readDetails(): Map<String, MangaDetail> = withContext(dispatchers.io) {
+        val assetManager = context.assets
+        val fileContent = runCatching {
+            assetManager
+                .open("catalog/details.json")
+                .bufferedReader()
+                .use { it.readText() }
+        }.getOrElse { throwable ->
+            Log.w("AssetCatalogRepository", "No detail fixtures found", throwable)
+            return@withContext emptyMap()
+        }
+
+        val records = json.decodeFromString<List<CatalogDetailRecord>>(fileContent)
+        records.associateBy(
+            keySelector = { it.id },
+            valueTransform = { record ->
+                val summary = MangaSummary(
+                    id = record.id,
+                    title = record.title,
+                    sourceId = record.sourceId,
+                    sourceName = record.sourceName,
+                    language = record.language,
+                    coverUrl = record.coverUrl,
+                    nsfw = record.nsfw ?: false,
+                    status = record.status?.toStatusEnum() ?: MangaStatus.UNKNOWN,
+                    tags = record.tags ?: emptyList(),
+                    description = record.description,
+                )
+                MangaDetail(
+                    summary = summary,
+                    author = record.author,
+                    artist = record.artist,
+                    status = summary.status,
+                    sourceUrl = record.sourceUrl,
+                    favorite = record.favorite ?: false,
+                    tags = record.tags ?: emptyList(),
+                    description = record.description,
+                    chapters = record.chapters?.map { chapter ->
+                        ChapterSummary(
+                            id = chapter.id,
+                            title = chapter.title,
+                            number = chapter.number,
+                            downloaded = chapter.downloaded ?: false,
+                            readProgress = chapter.readProgress?.toFloat() ?: 0f,
+                        )
+                    } ?: emptyList(),
+                )
+            }
+        )
+    }
+}
+
+@Serializable
+private data class CatalogRecord(
+    val id: String,
+    val title: String,
+    val sourceId: String,
+    val sourceName: String,
+    val language: String,
+    val coverUrl: String? = null,
+    val nsfw: Boolean? = null,
+    val status: String? = null,
+    val tags: List<String>? = null,
+    val description: String? = null,
+)
+
+@Serializable
+private data class CatalogDetailRecord(
+    val id: String,
+    val title: String,
+    val sourceId: String,
+    val sourceName: String,
+    val language: String,
+    val coverUrl: String? = null,
+    val nsfw: Boolean? = null,
+    val status: String? = null,
+    val tags: List<String>? = null,
+    val description: String? = null,
+    val author: String? = null,
+    val artist: String? = null,
+    val sourceUrl: String? = null,
+    val favorite: Boolean? = null,
+    val chapters: List<ChapterRecord>? = null,
+)
+
+@Serializable
+private data class ChapterRecord(
+    val id: String,
+    val title: String,
+    val number: Double? = null,
+    val downloaded: Boolean? = null,
+    val readProgress: Double? = null,
+)
+
+private fun String.toStatusEnum(): MangaStatus = when (lowercase()) {
+    "ongoing" -> MangaStatus.ONGOING
+    "completed" -> MangaStatus.COMPLETED
+    "hiatus" -> MangaStatus.HIATUS
+    "cancelled", "canceled" -> MangaStatus.CANCELLED
+    else -> MangaStatus.UNKNOWN
+}

--- a/android/data/src/main/java/com/chirui/data/db/ChiruiDatabase.kt
+++ b/android/data/src/main/java/com/chirui/data/db/ChiruiDatabase.kt
@@ -1,0 +1,7 @@
+package com.chirui.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [], version = 1, exportSchema = false)
+abstract class ChiruiDatabase : RoomDatabase()

--- a/android/data/src/main/java/com/chirui/data/di/CatalogModule.kt
+++ b/android/data/src/main/java/com/chirui/data/di/CatalogModule.kt
@@ -1,0 +1,18 @@
+package com.chirui.data.di
+
+import com.chirui.data.catalog.AssetCatalogRepository
+import com.chirui.domain.catalog.CatalogRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CatalogModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindCatalogRepository(repository: AssetCatalogRepository): CatalogRepository
+}

--- a/android/data/src/main/java/com/chirui/data/di/DatabaseModule.kt
+++ b/android/data/src/main/java/com/chirui/data/di/DatabaseModule.kt
@@ -1,0 +1,25 @@
+package com.chirui.data.di
+
+import android.content.Context
+import androidx.room.Room
+import com.chirui.data.db.ChiruiDatabase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): ChiruiDatabase =
+        Room.databaseBuilder(
+            context,
+            ChiruiDatabase::class.java,
+            "chirui.db"
+        ).fallbackToDestructiveMigration().build()
+}

--- a/android/data/src/main/java/com/chirui/data/di/DispatchersModule.kt
+++ b/android/data/src/main/java/com/chirui/data/di/DispatchersModule.kt
@@ -1,0 +1,42 @@
+package com.chirui.data.di
+
+import com.chirui.domain.DefaultDispatcher
+import com.chirui.domain.DispatcherProvider
+import com.chirui.domain.IoDispatcher
+import com.chirui.domain.MainDispatcher
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DispatchersModule {
+
+    @IoDispatcher
+    @Provides
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @DefaultDispatcher
+    @Provides
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @MainDispatcher
+    @Provides
+    fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+
+    @Provides
+    @Singleton
+    fun provideDispatcherProvider(
+        @IoDispatcher io: CoroutineDispatcher,
+        @DefaultDispatcher default: CoroutineDispatcher,
+        @MainDispatcher main: CoroutineDispatcher,
+    ): DispatcherProvider = object : DispatcherProvider {
+        override val io: CoroutineDispatcher = io
+        override val default: CoroutineDispatcher = default
+        override val main: CoroutineDispatcher = main
+    }
+}

--- a/android/data/src/main/java/com/chirui/data/di/DownloadModule.kt
+++ b/android/data/src/main/java/com/chirui/data/di/DownloadModule.kt
@@ -1,0 +1,20 @@
+package com.chirui.data.di
+
+import com.chirui.data.downloads.AssetDownloadRepository
+import com.chirui.domain.downloads.DownloadRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DownloadModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindDownloadRepository(
+        impl: AssetDownloadRepository,
+    ): DownloadRepository
+}

--- a/android/data/src/main/java/com/chirui/data/di/NetworkModule.kt
+++ b/android/data/src/main/java/com/chirui/data/di/NetworkModule.kt
@@ -1,0 +1,36 @@
+package com.chirui.data.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BASIC
+        }
+        return OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(client: OkHttpClient): Retrofit =
+        Retrofit.Builder()
+            .baseUrl("https://example.invalid/")
+            .client(client)
+            .addConverterFactory(MoshiConverterFactory.create())
+            .build()
+}

--- a/android/data/src/main/java/com/chirui/data/di/ParsersModule.kt
+++ b/android/data/src/main/java/com/chirui/data/di/ParsersModule.kt
@@ -1,0 +1,18 @@
+package com.chirui.data.di
+
+import com.chirui.data.parsers.AssetParserRegistry
+import com.chirui.parsers.ParserRegistry
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ParsersModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindParserRegistry(registry: AssetParserRegistry): ParserRegistry
+}

--- a/android/data/src/main/java/com/chirui/data/di/PreferencesModule.kt
+++ b/android/data/src/main/java/com/chirui/data/di/PreferencesModule.kt
@@ -1,0 +1,30 @@
+package com.chirui.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PreferencesModule {
+
+    @Provides
+    @Singleton
+    fun providePreferencesDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler { emptyPreferences() },
+            produceFile = { context.preferencesDataStoreFile("chirui-user-prefs") }
+        )
+}

--- a/android/data/src/main/java/com/chirui/data/di/ReaderModule.kt
+++ b/android/data/src/main/java/com/chirui/data/di/ReaderModule.kt
@@ -1,0 +1,15 @@
+package com.chirui.data.di
+
+import com.chirui.data.reader.AssetReaderRepository
+import com.chirui.domain.reader.ReaderRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface ReaderModule {
+    @Binds
+    fun bindReaderRepository(impl: AssetReaderRepository): ReaderRepository
+}

--- a/android/data/src/main/java/com/chirui/data/downloads/AssetDownloadRepository.kt
+++ b/android/data/src/main/java/com/chirui/data/downloads/AssetDownloadRepository.kt
@@ -1,0 +1,132 @@
+package com.chirui.data.downloads
+
+import android.content.Context
+import com.chirui.domain.DispatcherProvider
+import com.chirui.domain.downloads.DownloadRepository
+import com.chirui.domain.model.DownloadChapter
+import com.chirui.domain.model.DownloadItem
+import com.chirui.domain.model.DownloadStatus
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Singleton
+class AssetDownloadRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatchers: DispatcherProvider,
+) : DownloadRepository {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val queue = MutableStateFlow(loadFixtures())
+
+    override fun observeQueue(): Flow<List<DownloadItem>> = queue
+
+    override suspend fun pause(id: String) {
+        updateStatus(id) { current ->
+            when (current.status) {
+                DownloadStatus.DOWNLOADING -> current.copy(status = DownloadStatus.PAUSED)
+                else -> current
+            }
+        }
+    }
+
+    override suspend fun resume(id: String) {
+        updateStatus(id) { current ->
+            when (current.status) {
+                DownloadStatus.PAUSED, DownloadStatus.FAILED, DownloadStatus.CANCELED ->
+                    current.copy(status = DownloadStatus.DOWNLOADING)
+                else -> current
+            }
+        }
+    }
+
+    override suspend fun cancel(id: String) {
+        updateStatus(id) { current ->
+            when (current.status) {
+                DownloadStatus.COMPLETED -> current
+                else -> current.copy(status = DownloadStatus.CANCELED, progress = 0f)
+            }
+        }
+    }
+
+    override suspend fun retry(id: String) {
+        updateStatus(id) { current ->
+            when (current.status) {
+                DownloadStatus.FAILED, DownloadStatus.CANCELED -> current.copy(status = DownloadStatus.QUEUED)
+                else -> current
+            }
+        }
+    }
+
+    private suspend fun updateStatus(id: String, transform: (DownloadItem) -> DownloadItem) {
+        withContext(dispatchers.io) {
+            queue.update { downloads ->
+                downloads.map { item -> if (item.id == id) transform(item) else item }
+            }
+        }
+    }
+
+    private fun loadFixtures(): List<DownloadItem> {
+        val raw = runCatching {
+            context.assets.open("downloads/queue.json").use { it.bufferedReader().readText() }
+        }.getOrNull() ?: return emptyList()
+
+        val payload = runCatching { json.decodeFromString(DownloadPayload.serializer(), raw) }.getOrNull()
+            ?: return emptyList()
+
+        return payload.downloads.map { download ->
+            DownloadItem(
+                id = download.id,
+                title = download.title,
+                source = download.source,
+                coverUrl = download.coverUrl,
+                status = download.status.toStatus(),
+                progress = download.progress,
+                etaMinutes = download.etaMinutes,
+                sizeLabel = download.sizeLabel,
+                chapters = download.chapters.map { chapter ->
+                    DownloadChapter(
+                        id = chapter.id,
+                        name = chapter.name,
+                        progress = chapter.progress,
+                    )
+                }
+            )
+        }
+    }
+
+    @Serializable
+    private data class DownloadPayload(
+        val downloads: List<DownloadFixture> = emptyList(),
+    )
+
+    @Serializable
+    private data class DownloadFixture(
+        val id: String,
+        val title: String,
+        val source: String,
+        val coverUrl: String? = null,
+        val status: String = "QUEUED",
+        val progress: Float = 0f,
+        val etaMinutes: Int? = null,
+        val sizeLabel: String? = null,
+        val chapters: List<DownloadChapterFixture> = emptyList(),
+    )
+
+    @Serializable
+    private data class DownloadChapterFixture(
+        val id: String,
+        val name: String,
+        val progress: Float = 0f,
+    )
+
+    private fun String.toStatus(): DownloadStatus = runCatching {
+        DownloadStatus.valueOf(uppercase())
+    }.getOrDefault(DownloadStatus.QUEUED)
+}

--- a/android/data/src/main/java/com/chirui/data/parsers/AssetParserRegistry.kt
+++ b/android/data/src/main/java/com/chirui/data/parsers/AssetParserRegistry.kt
@@ -1,0 +1,88 @@
+package com.chirui.data.parsers
+
+import android.content.Context
+import android.util.Log
+import com.chirui.domain.DispatcherProvider
+import com.chirui.domain.model.SourceDescriptor
+import com.chirui.parsers.ParserRegistry
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Singleton
+class AssetParserRegistry @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatchers: DispatcherProvider,
+) : ParserRegistry {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val scope = CoroutineScope(dispatchers.io + SupervisorJob())
+    private val sources = MutableStateFlow<List<SourceDescriptor>>(emptyList())
+    private val enabledState = mutableMapOf<String, Boolean>()
+
+    init {
+        scope.launch { reload() }
+    }
+
+    override fun availableSources(): Flow<List<SourceDescriptor>> = sources.asStateFlow()
+
+    override suspend fun setEnabled(sourceId: String, enabled: Boolean) {
+        enabledState[sourceId] = enabled
+        sources.value = sources.value.map { descriptor ->
+            if (descriptor.id == sourceId) descriptor.copy(enabled = enabled) else descriptor
+        }
+    }
+
+    override suspend fun reload() {
+        val data = runCatching { readSourceJson() }.getOrElse { throwable ->
+            Log.e("AssetParserRegistry", "Failed to load source metadata", throwable)
+            emptyList()
+        }
+        sources.value = data.map { descriptor ->
+            val cachedEnabled = enabledState[descriptor.id]
+            if (cachedEnabled == null) descriptor else descriptor.copy(enabled = cachedEnabled)
+        }
+    }
+
+    private suspend fun readSourceJson(): List<SourceDescriptor> = withContext(dispatchers.io) {
+        val assetManager = context.assets
+        val fileContent = assetManager
+            .open("sources/sources.json")
+            .bufferedReader()
+            .use { it.readText() }
+
+        val records = json.decodeFromString<List<SourceRecord>>(fileContent)
+        records.map { record ->
+            SourceDescriptor(
+                id = record.id,
+                name = record.name,
+                language = record.language,
+                description = record.description,
+                nsfw = record.nsfw,
+                iconPath = record.iconPath,
+                enabled = record.enabled ?: true,
+            )
+        }
+    }
+}
+
+@Serializable
+private data class SourceRecord(
+    val id: String,
+    val name: String,
+    val language: String,
+    val description: String? = null,
+    val nsfw: Boolean = false,
+    @SerialName("iconPath") val iconPath: String? = null,
+    val enabled: Boolean? = null,
+)

--- a/android/data/src/main/java/com/chirui/data/reader/AssetReaderRepository.kt
+++ b/android/data/src/main/java/com/chirui/data/reader/AssetReaderRepository.kt
@@ -1,0 +1,70 @@
+package com.chirui.data.reader
+
+import android.content.Context
+import com.chirui.domain.DispatcherProvider
+import com.chirui.domain.model.ReaderChapter
+import com.chirui.domain.model.ReaderPage
+import com.chirui.domain.reader.ReaderRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Singleton
+class AssetReaderRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val dispatchers: DispatcherProvider,
+) : ReaderRepository {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun loadChapter(chapterId: String): ReaderChapter? = withContext(dispatchers.io) {
+        val raw = runCatching {
+            context.assets.open("reader/chapters.json").use { stream ->
+                stream.bufferedReader().readText()
+            }
+        }.getOrElse { return@withContext null }
+
+        val payload = runCatching { json.decodeFromString(ReaderPayload.serializer(), raw) }.getOrNull()
+            ?: return@withContext null
+
+        val chapter = payload.chapters.firstOrNull { it.chapterId == chapterId } ?: return@withContext null
+
+        ReaderChapter(
+            chapterId = chapter.chapterId,
+            mangaId = chapter.mangaId,
+            mangaTitle = chapter.mangaTitle,
+            chapterTitle = chapter.chapterTitle,
+            pages = chapter.pages.map { page ->
+                ReaderPage(
+                    index = page.index,
+                    imageUrl = page.imageUrl,
+                    width = page.width,
+                    height = page.height,
+                )
+            }
+        )
+    }
+
+    @Serializable
+    private data class ReaderPayload(val chapters: List<ReaderChapterPayload> = emptyList())
+
+    @Serializable
+    private data class ReaderChapterPayload(
+        val chapterId: String,
+        val mangaId: String,
+        val mangaTitle: String,
+        val chapterTitle: String,
+        val pages: List<ReaderPagePayload> = emptyList(),
+    )
+
+    @Serializable
+    private data class ReaderPagePayload(
+        val index: Int,
+        val imageUrl: String,
+        val width: Int? = null,
+        val height: Int? = null,
+    )
+}

--- a/android/domain/build.gradle.kts
+++ b/android/domain/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.chirui.domain"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 34
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation("javax.inject:javax.inject:1")
+}

--- a/android/domain/src/main/java/com/chirui/domain/Dispatchers.kt
+++ b/android/domain/src/main/java/com/chirui/domain/Dispatchers.kt
@@ -1,0 +1,22 @@
+package com.chirui.domain
+
+import javax.inject.Qualifier
+import kotlinx.coroutines.CoroutineDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class MainDispatcher
+
+interface DispatcherProvider {
+    val io: CoroutineDispatcher
+    val default: CoroutineDispatcher
+    val main: CoroutineDispatcher
+}

--- a/android/domain/src/main/java/com/chirui/domain/catalog/CatalogRepository.kt
+++ b/android/domain/src/main/java/com/chirui/domain/catalog/CatalogRepository.kt
@@ -1,0 +1,12 @@
+package com.chirui.domain.catalog
+
+import com.chirui.domain.model.MangaDetail
+import com.chirui.domain.model.MangaSummary
+import kotlinx.coroutines.flow.Flow
+
+interface CatalogRepository {
+    fun catalogEntries(): Flow<List<MangaSummary>>
+    suspend fun reload()
+    suspend fun mangaDetail(id: String): MangaDetail?
+    suspend fun setFavorite(id: String, favorite: Boolean)
+}

--- a/android/domain/src/main/java/com/chirui/domain/downloads/DownloadRepository.kt
+++ b/android/domain/src/main/java/com/chirui/domain/downloads/DownloadRepository.kt
@@ -1,0 +1,16 @@
+package com.chirui.domain.downloads
+
+import com.chirui.domain.model.DownloadItem
+import kotlinx.coroutines.flow.Flow
+
+interface DownloadRepository {
+    fun observeQueue(): Flow<List<DownloadItem>>
+
+    suspend fun pause(id: String)
+
+    suspend fun resume(id: String)
+
+    suspend fun cancel(id: String)
+
+    suspend fun retry(id: String)
+}

--- a/android/domain/src/main/java/com/chirui/domain/model/ChapterSummary.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/ChapterSummary.kt
@@ -1,0 +1,12 @@
+package com.chirui.domain.model
+
+/**
+ * Lightweight chapter metadata used by the catalog/detail UI before the reader pipeline is wired.
+ */
+data class ChapterSummary(
+    val id: String,
+    val title: String,
+    val number: Double? = null,
+    val downloaded: Boolean = false,
+    val readProgress: Float = 0f,
+)

--- a/android/domain/src/main/java/com/chirui/domain/model/DownloadChapter.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/DownloadChapter.kt
@@ -1,0 +1,7 @@
+package com.chirui.domain.model
+
+data class DownloadChapter(
+    val id: String,
+    val name: String,
+    val progress: Float = 0f,
+)

--- a/android/domain/src/main/java/com/chirui/domain/model/DownloadItem.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/DownloadItem.kt
@@ -1,0 +1,13 @@
+package com.chirui.domain.model
+
+data class DownloadItem(
+    val id: String,
+    val title: String,
+    val source: String,
+    val coverUrl: String? = null,
+    val status: DownloadStatus = DownloadStatus.QUEUED,
+    val progress: Float = 0f,
+    val etaMinutes: Int? = null,
+    val sizeLabel: String? = null,
+    val chapters: List<DownloadChapter> = emptyList(),
+)

--- a/android/domain/src/main/java/com/chirui/domain/model/DownloadStatus.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/DownloadStatus.kt
@@ -1,0 +1,10 @@
+package com.chirui.domain.model
+
+enum class DownloadStatus {
+    QUEUED,
+    DOWNLOADING,
+    PAUSED,
+    COMPLETED,
+    FAILED,
+    CANCELED,
+}

--- a/android/domain/src/main/java/com/chirui/domain/model/MangaDetail.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/MangaDetail.kt
@@ -1,0 +1,16 @@
+package com.chirui.domain.model
+
+/**
+ * Expanded metadata for a manga entry sourced from Kotatsu fixtures or parsers.
+ */
+data class MangaDetail(
+    val summary: MangaSummary,
+    val author: String? = null,
+    val artist: String? = null,
+    val status: MangaStatus = MangaStatus.UNKNOWN,
+    val sourceUrl: String? = null,
+    val favorite: Boolean = false,
+    val tags: List<String> = emptyList(),
+    val description: String? = null,
+    val chapters: List<ChapterSummary> = emptyList(),
+)

--- a/android/domain/src/main/java/com/chirui/domain/model/MangaStatus.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/MangaStatus.kt
@@ -1,0 +1,9 @@
+package com.chirui.domain.model
+
+enum class MangaStatus {
+    ONGOING,
+    COMPLETED,
+    HIATUS,
+    CANCELLED,
+    UNKNOWN,
+}

--- a/android/domain/src/main/java/com/chirui/domain/model/MangaSummary.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/MangaSummary.kt
@@ -1,0 +1,14 @@
+package com.chirui.domain.model
+
+data class MangaSummary(
+    val id: String,
+    val title: String,
+    val sourceId: String,
+    val sourceName: String,
+    val language: String,
+    val coverUrl: String?,
+    val nsfw: Boolean,
+    val status: MangaStatus = MangaStatus.UNKNOWN,
+    val tags: List<String> = emptyList(),
+    val description: String? = null,
+)

--- a/android/domain/src/main/java/com/chirui/domain/model/ReaderChapter.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/ReaderChapter.kt
@@ -1,0 +1,12 @@
+package com.chirui.domain.model
+
+/**
+ * Chapter payload for the reader, including ordered pages and metadata.
+ */
+data class ReaderChapter(
+    val chapterId: String,
+    val mangaId: String,
+    val mangaTitle: String,
+    val chapterTitle: String,
+    val pages: List<ReaderPage>,
+)

--- a/android/domain/src/main/java/com/chirui/domain/model/ReaderPage.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/ReaderPage.kt
@@ -1,0 +1,11 @@
+package com.chirui.domain.model
+
+/**
+ * Represents a single page inside a chapter for the reader pipeline.
+ */
+data class ReaderPage(
+    val index: Int,
+    val imageUrl: String,
+    val width: Int? = null,
+    val height: Int? = null,
+)

--- a/android/domain/src/main/java/com/chirui/domain/model/SourceDescriptor.kt
+++ b/android/domain/src/main/java/com/chirui/domain/model/SourceDescriptor.kt
@@ -1,0 +1,11 @@
+package com.chirui.domain.model
+
+data class SourceDescriptor(
+    val id: String,
+    val name: String,
+    val language: String,
+    val description: String? = null,
+    val nsfw: Boolean = false,
+    val iconPath: String? = null,
+    val enabled: Boolean = true,
+)

--- a/android/domain/src/main/java/com/chirui/domain/reader/ReaderRepository.kt
+++ b/android/domain/src/main/java/com/chirui/domain/reader/ReaderRepository.kt
@@ -1,0 +1,7 @@
+package com.chirui.domain.reader
+
+import com.chirui.domain.model.ReaderChapter
+
+interface ReaderRepository {
+    suspend fun loadChapter(chapterId: String): ReaderChapter?
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official

--- a/android/parsers/build.gradle.kts
+++ b/android/parsers/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.chirui.parsers"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 34
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":domain"))
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+}

--- a/android/parsers/src/main/java/com/chirui/parsers/ParserRegistry.kt
+++ b/android/parsers/src/main/java/com/chirui/parsers/ParserRegistry.kt
@@ -1,0 +1,50 @@
+package com.chirui.parsers
+
+import com.chirui.domain.model.SourceDescriptor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+interface ParserRegistry {
+    fun availableSources(): Flow<List<SourceDescriptor>>
+    suspend fun setEnabled(sourceId: String, enabled: Boolean)
+    suspend fun reload()
+}
+
+class StaticParserRegistry @Inject constructor() : ParserRegistry {
+    private val sources = MutableStateFlow(
+        listOf(
+            SourceDescriptor(
+                id = "demo-english",
+                name = "Kotatsu Demo (EN)",
+                language = "en",
+                description = "Placeholder source loaded before parser ingestion is wired.",
+                nsfw = false,
+                iconPath = null,
+                enabled = true,
+            ),
+            SourceDescriptor(
+                id = "demo-japanese",
+                name = "Kotatsu Demo (JP)",
+                language = "ja",
+                description = "Scaffolds language filtering hooks.",
+                nsfw = true,
+                iconPath = null,
+                enabled = true,
+            ),
+        )
+    )
+
+    override fun availableSources(): Flow<List<SourceDescriptor>> = sources.asStateFlow()
+
+    override suspend fun setEnabled(sourceId: String, enabled: Boolean) {
+        sources.value = sources.value.map { descriptor ->
+            if (descriptor.id == sourceId) descriptor.copy(enabled = enabled) else descriptor
+        }
+    }
+
+    override suspend fun reload() {
+        // no-op for static bootstrap implementation
+    }
+}

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ChiruiReader"
+include(":app")
+include(":domain")
+include(":data")
+include(":parsers")

--- a/docs/KOTATSU_ASSET_MANIFEST.md
+++ b/docs/KOTATSU_ASSET_MANIFEST.md
@@ -1,0 +1,46 @@
+# Kotatsu Asset Manifest for Chirui Reader
+
+Use this manifest to ensure **every asset from your Kotatsu forks** is imported into the native Android project. Keep it updated
+as you sync from upstream Kotatsu and your forks. _Last updated: 2025-11-25 18:24 UTC._
+
+## Forks to source from
+- `github.com/swolem12/Kotatsu` (primary fork with app assets)
+- `github.com/swolem12/kotatsu-parsers` (parser/source icons, metadata)
+- `github.com/swolem12/kotatsu-syncserver` (sync service assets/config references)
+- `github.com/swolem12/kotatsuwebsite` (marketing/branding collateral, copy)
+- `github.com/swolem12/kotatsu-dl` (downloader UI assets, CLI references)
+- `github.com/swolem12/kotatsu-dl-gui` (desktop GUI assets that may inform download flows)
+
+## Asset categories and destinations
+
+| Category | Examples to import | Android destination |
+| --- | --- | --- |
+| Branding & launcher | Adaptive icons (`ic_launcher.xml`), legacy PNGs, monochrome versions, feature graphic, splash/launch screens | `app/src/main/res/mipmap*`, `res/drawable*` |
+| Palette & typography | Color tokens, gradients, elevation overlays, font files | `res/values/colors.xml`, `res/font`, Compose theme | 
+| Reader UI | Mode toggles (single/double/webtoon), gestures, zoom/pan controls, page slider thumbs, scrollbar indicators | `res/drawable`, `res/drawable-anydpi` (VectorDrawable preferred) |
+| Catalog & library | Placeholder covers, empty-state illustrations, badges, chips, rating icons | `res/drawable`, `res/raw` (Lottie/JSON) |
+| Source extensions | Source logos/icons, language badges, NSFW markers, extension banners | `res/drawable`, `app/src/main/assets/sources/` (metadata) |
+| Strings & i18n | Menu labels, actions, error strings, descriptions from all locales | `res/values/strings.xml`, locale-specific `values-xx/` |
+| Fixtures & demos | Sample catalog entries, parser metadata, fake chapters/pages for offline demos | `app/src/main/assets/fixtures/` |
+| Marketing | Screenshots, feature graphics, changelog templates, privacy text | `docs/marketing/` (for store collateral) |
+
+## Sync checklist
+- [ ] Pull the latest assets from each fork and drop them into the destinations above.
+- [ ] Convert SVGs to VectorDrawable where possible; keep raster fallbacks for complex art.
+- [ ] Deduplicate filenames and ensure densities (`mdpi`-`xxxhdpi`) are covered for PNGs.
+- [ ] Verify all strings have keys and translations across locales you ship.
+- [ ] Update Compose theme to reference imported color/typography tokens.
+- [ ] Record hashes (e.g., SHA256) for critical assets in this manifest when added.
+
+## Pending assets to list explicitly
+Add rows here as you ingest assets so the manifest stays authoritative:
+
+| Asset | Source fork/path | Destination | Notes | Hash |
+| --- | --- | --- | --- | --- |
+| _example_: `ic_launcher_adaptive.xml` | `swolem12/Kotatsu:app/src/main/res/mipmap-anydpi-v26/` | `android/app/src/main/res/mipmap-anydpi-v26/` | Adaptive icon | _(add)_ |
+| _example_: `source_mangadex.svg` | `swolem12/kotatsu-parsers:assets/icons/` | `android/app/src/main/res/drawable-anydpi/` | Parser icon | _(add)_ |
+| `sources.json` | `swolem12/kotatsu-parsers:assets/sources.json` (and other forks when updated) | `android/app/src/main/assets/sources/` | Bundled registry powering the source list screen; replace placeholder entries with full fork sync. | _(add)_ |
+| `featured.json` | `swolem12/Kotatsu` and `swolem12/kotatsu-parsers` fixtures | `android/app/src/main/assets/catalog/` | Offline catalog feed for the Discover tab; swap in real covers/titles from forks. | _(add)_ |
+| `details.json` | `swolem12/Kotatsu` fixtures and parser outputs | `android/app/src/main/assets/catalog/` | Bundled manga detail + chapter metadata for offline detail screen demos. | _(add)_ |
+| `reader/chapters.json` | `swolem12/Kotatsu` chapter samples (or parser outputs) | `android/app/src/main/assets/reader/` | Fixture-backed reader pages for swipe/slider demo until the image pipeline is wired. | _(add)_ |
+| `downloads/queue.json` | `swolem12/kotatsu-dl` + `swolem12/kotatsu-dl-gui` fixtures | `android/app/src/main/assets/downloads/` | Fixture download queue for the skeleton downloads screen (status icons/strings to follow). | _(add)_ |

--- a/docs/NEXT_STEPS_TODO.md
+++ b/docs/NEXT_STEPS_TODO.md
@@ -1,0 +1,37 @@
+# Native Kotatsu Build — Next Approval TODO
+_Last updated: 2025-11-25 18:24 UTC._
+
+A concise checklist of the next implementation steps for the Android app so you can approve milestones quickly. These tasks build on the current Compose shell and theme, and they reference all supplied Kotatsu forks:
+
+- `github.com/swolem12/Kotatsu`
+- `github.com/swolem12/kotatsu-parsers`
+- `github.com/swolem12/kotatsu-syncserver`
+- `github.com/swolem12/kotatsuwebsite`
+- `github.com/swolem12/kotatsu-dl`
+- `github.com/swolem12/kotatsu-dl-gui`
+
+## Immediate (Sprint 1)
+- [ ] **Asset import pass**: ingest icons/illustrations/strings from every fork into `android/app/src/main/res` and `assets/`, updating `docs/KOTATSU_ASSET_MANIFEST.md` with paths and checksums.
+- [x] **Dependency wiring**: add Hilt DI, coroutine dispatchers, Retrofit/OkHttp core, and Room/Datastore baseline modules; split into `app`, `domain`, `data`, and `parsers` modules for clean boundaries.
+- [x] **Source registry scaffold**: load parser/source metadata from `kotatsu-parsers` JSON/fixtures into `assets/` and surface a basic source list screen with enable/disable toggles and language filters.
+- [x] **Navigation polish**: hook bottom navigation destinations to dedicated `NavHost` routes and stub top app bars per section (Home, Catalog, Library, Downloads, Settings).
+
+## Near-term (Sprint 2)
+- [x] **Catalog grid**: query sources for paginated listings, render cards with cover, title, language, NSFW flag, and lazy paging; add filters (genre, status, sort) and search that fans out to enabled sources.
+- [x] **Manga detail**: fetch metadata/chapters from sources; implement actions (favorite, download, open reader, share) and chapter list with badges for downloaded/partially read.
+- [x] **Reader foundation**: ship a bundled fixture-backed reader route with swipe/slider navigation for Kotatsu chapters; upgrade later with caching/prefetch modes.
+- [x] **Downloads skeleton**: create a download queue UI, background worker setup, and notifications using assets from `kotatsu-dl`/`kotatsu-dl-gui` (icons, status glyphs).
+
+## Mid-term (Sprint 3)
+- [ ] **Library & history**: add shelves/categories, sort options, and favorites; persist history with resume; support bulk actions and pinned items.
+- [ ] **Offline & import**: implement save-on-open and explicit chapter downloads; add CBZ/CBR/ZIP/EPUB import with cover extraction and media scanning.
+- [ ] **Tracking services**: integrate AniList/MyAnimeList/Kitsu/Shikimori with two-way sync, background update workers, and error surfaces.
+
+## Finalization (Sprint 4)
+- [ ] **Backup & sync**: optional account sign-in tied to `kotatsu-syncserver` for cloud backup; local encrypted export/import; migration tool for legacy web/PWA data.
+- [ ] **Polish & release**: Material You/dynamic color, accessibility passes, crash/empty states using imported illustrations; Play/F-Droid release pipeline, store listings, and automated screenshots.
+
+## How to use this list
+- Use it as the approval gate for each sprint: check off items once merged.
+- Keep `docs/KOTATSU_ASSET_MANIFEST.md` updated whenever assets from any fork are imported or changed.
+- Align commits/PRs to the smallest bullet that still delivers a user-visible milestone.

--- a/src/styles.css
+++ b/src/styles.css
@@ -635,6 +635,69 @@ button:disabled {
   margin-bottom: var(--spacing-lg);
 }
 
+.catalog-pagination {
+  margin-top: var(--spacing-lg);
+  padding: var(--spacing-md);
+  background-color: var(--md-surface);
+  border: 1px solid var(--md-outline);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.pagination-content {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.pagination-info {
+  font-size: var(--font-size-sm);
+  color: var(--md-on-surface);
+  opacity: 0.8;
+}
+
+.pagination-buttons {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.pagination-btn {
+  background-color: var(--md-background);
+  color: var(--md-on-surface);
+  border: 1px solid var(--md-outline);
+  padding: 8px 12px;
+  min-width: 40px;
+  text-align: center;
+}
+
+.pagination-btn.active {
+  background-color: var(--md-primary);
+  color: var(--md-on-primary);
+  border-color: var(--md-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.pagination-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--md-surface-variant);
+}
+
+.pagination-ellipsis {
+  color: var(--md-on-surface);
+  opacity: 0.6;
+  padding: 0 4px;
+}
+
 /* Manga Detail View */
 .manga-detail-view {
   max-width: 1200px;


### PR DESCRIPTION
## Summary
- build a fixture-backed downloads queue screen with pause/resume/cancel/retry controls and chapter progress chips
- add a download repository/view model plus DI bindings that load demo queue data from bundled assets
- refresh docs and roadmap timestamps to record the downloads skeleton milestone and new asset manifest entry

## Testing
- not run (Android tooling unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925d375fbb48330a23ebdc0c1af197a)